### PR TITLE
feat(a11y): Phase 2 — form ARIA wiring across all five forms

### DIFF
--- a/src/features/donations/donation-form.test.tsx
+++ b/src/features/donations/donation-form.test.tsx
@@ -53,6 +53,41 @@ describe('DonationForm', () => {
     })
   })
 
+  it('sets aria-invalid and aria-describedby on invalid fields after submit', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(
+      <DonationForm donors={mockDonors} onSubmit={vi.fn()} submitLabel="Guardar" />
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Guardar' }))
+
+    await waitFor(() => {
+      const amountInput = screen.getByLabelText('Monto')
+      expect(amountInput).toHaveAttribute('aria-invalid', 'true')
+      expect(amountInput).toHaveAttribute('aria-describedby', 'amount-error')
+      expect(document.getElementById('amount-error')).toHaveAttribute('role', 'alert')
+
+      const dateInput = screen.getByLabelText('Fecha')
+      expect(dateInput).toHaveAttribute('aria-invalid', 'true')
+      expect(dateInput).toHaveAttribute('aria-describedby', 'donationDate-error')
+      expect(document.getElementById('donationDate-error')).toHaveAttribute('role', 'alert')
+    })
+  })
+
+  it('has no aria-invalid or aria-describedby before submit', () => {
+    renderWithProviders(
+      <DonationForm donors={mockDonors} onSubmit={vi.fn()} submitLabel="Guardar" />
+    )
+
+    const amountInput = screen.getByLabelText('Monto')
+    expect(amountInput).toHaveAttribute('aria-invalid', 'false')
+    expect(amountInput).not.toHaveAttribute('aria-describedby')
+
+    const dateInput = screen.getByLabelText('Fecha')
+    expect(dateInput).toHaveAttribute('aria-invalid', 'false')
+    expect(dateInput).not.toHaveAttribute('aria-describedby')
+  })
+
   it('renders with default values for edit mode', () => {
     renderWithProviders(
       <DonationForm

--- a/src/features/donations/donation-form.test.tsx
+++ b/src/features/donations/donation-form.test.tsx
@@ -56,7 +56,11 @@ describe('DonationForm', () => {
   it('sets aria-invalid and aria-describedby on invalid fields after submit', async () => {
     const user = userEvent.setup()
     renderWithProviders(
-      <DonationForm donors={mockDonors} onSubmit={vi.fn()} submitLabel="Guardar" />
+      <DonationForm
+        donors={mockDonors}
+        onSubmit={vi.fn()}
+        submitLabel="Guardar"
+      />
     )
 
     await user.click(screen.getByRole('button', { name: 'Guardar' }))
@@ -65,18 +69,31 @@ describe('DonationForm', () => {
       const amountInput = screen.getByLabelText('Monto')
       expect(amountInput).toHaveAttribute('aria-invalid', 'true')
       expect(amountInput).toHaveAttribute('aria-describedby', 'amount-error')
-      expect(document.getElementById('amount-error')).toHaveAttribute('role', 'alert')
+      expect(document.getElementById('amount-error')).toHaveAttribute(
+        'role',
+        'alert'
+      )
 
       const dateInput = screen.getByLabelText('Fecha')
       expect(dateInput).toHaveAttribute('aria-invalid', 'true')
-      expect(dateInput).toHaveAttribute('aria-describedby', 'donationDate-error')
-      expect(document.getElementById('donationDate-error')).toHaveAttribute('role', 'alert')
+      expect(dateInput).toHaveAttribute(
+        'aria-describedby',
+        'donationDate-error'
+      )
+      expect(document.getElementById('donationDate-error')).toHaveAttribute(
+        'role',
+        'alert'
+      )
     })
   })
 
   it('has no aria-invalid or aria-describedby before submit', () => {
     renderWithProviders(
-      <DonationForm donors={mockDonors} onSubmit={vi.fn()} submitLabel="Guardar" />
+      <DonationForm
+        donors={mockDonors}
+        onSubmit={vi.fn()}
+        submitLabel="Guardar"
+      />
     )
 
     const amountInput = screen.getByLabelText('Monto')

--- a/src/features/donations/donation-form.tsx
+++ b/src/features/donations/donation-form.tsx
@@ -65,25 +65,45 @@ export function DonationForm({
             type="number"
             step="0.01"
             min="0.01"
+            aria-invalid={!!errors.amount}
+            aria-describedby={errors.amount ? 'amount-error' : undefined}
             {...register('amount', { valueAsNumber: true })}
           />
           {errors.amount && (
-            <p className="text-sm text-destructive">{errors.amount.message}</p>
+            <p
+              id="amount-error"
+              role="alert"
+              className="text-sm text-destructive"
+            >
+              {errors.amount.message}
+            </p>
           )}
         </div>
 
         <div className="space-y-2">
           <Label htmlFor="donationDate">{t('donations.date')}</Label>
-          <Input id="donationDate" type="date" {...register('donationDate')} />
+          <Input
+            id="donationDate"
+            type="date"
+            aria-invalid={!!errors.donationDate}
+            aria-describedby={
+              errors.donationDate ? 'donationDate-error' : undefined
+            }
+            {...register('donationDate')}
+          />
           {errors.donationDate && (
-            <p className="text-sm text-destructive">
+            <p
+              id="donationDate-error"
+              role="alert"
+              className="text-sm text-destructive"
+            >
               {errors.donationDate.message}
             </p>
           )}
         </div>
 
         <div className="space-y-2">
-          <Label>{t('donations.type')}</Label>
+          <Label htmlFor="donationType">{t('donations.type')}</Label>
           <Controller
             control={control}
             name="donationType"
@@ -92,7 +112,13 @@ export function DonationForm({
                 value={field.value ? t(`donations.types.${field.value}`) : ''}
                 onValueChange={field.onChange}
               >
-                <SelectTrigger>
+                <SelectTrigger
+                  id="donationType"
+                  aria-invalid={!!errors.donationType}
+                  aria-describedby={
+                    errors.donationType ? 'donationType-error' : undefined
+                  }
+                >
                   <SelectValue placeholder={t('donations.selectType')} />
                 </SelectTrigger>
                 <SelectContent>
@@ -106,14 +132,18 @@ export function DonationForm({
             )}
           />
           {errors.donationType && (
-            <p className="text-sm text-destructive">
+            <p
+              id="donationType-error"
+              role="alert"
+              className="text-sm text-destructive"
+            >
               {errors.donationType.message}
             </p>
           )}
         </div>
 
         <div className="space-y-2">
-          <Label>{t('donations.incomeMethod')}</Label>
+          <Label htmlFor="paymentMethod">{t('donations.incomeMethod')}</Label>
           <Controller
             control={control}
             name="paymentMethod"
@@ -126,7 +156,13 @@ export function DonationForm({
                 }
                 onValueChange={field.onChange}
               >
-                <SelectTrigger>
+                <SelectTrigger
+                  id="paymentMethod"
+                  aria-invalid={!!errors.paymentMethod}
+                  aria-describedby={
+                    errors.paymentMethod ? 'paymentMethod-error' : undefined
+                  }
+                >
                   <SelectValue placeholder={t('donations.selectPayment')} />
                 </SelectTrigger>
                 <SelectContent>
@@ -140,7 +176,11 @@ export function DonationForm({
             )}
           />
           {errors.paymentMethod && (
-            <p className="text-sm text-destructive">
+            <p
+              id="paymentMethod-error"
+              role="alert"
+              className="text-sm text-destructive"
+            >
               {errors.paymentMethod.message}
             </p>
           )}

--- a/src/features/donors/donor-form.test.tsx
+++ b/src/features/donors/donor-form.test.tsx
@@ -50,6 +50,46 @@ describe('DonorForm', () => {
     expect(screen.getByLabelText(/Email/)).toHaveValue('juan@test.com')
   })
 
+  it('sets aria-invalid and aria-describedby on invalid submit', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<DonorForm onSubmit={vi.fn()} submitLabel="Guardar" />)
+
+    await user.click(screen.getByRole('button', { name: 'Guardar' }))
+
+    await waitFor(() => {
+      const fullNameInput = screen.getByLabelText('Nombre completo')
+      expect(fullNameInput).toHaveAttribute('aria-invalid', 'true')
+      expect(fullNameInput).toHaveAttribute(
+        'aria-describedby',
+        'fullName-error'
+      )
+      expect(document.getElementById('fullName-error')).toHaveAttribute(
+        'role',
+        'alert'
+      )
+
+      const dniNieInput = screen.getByLabelText('DNI/NIE')
+      expect(dniNieInput).toHaveAttribute('aria-invalid', 'true')
+      expect(dniNieInput).toHaveAttribute('aria-describedby', 'dniNie-error')
+      expect(document.getElementById('dniNie-error')).toHaveAttribute(
+        'role',
+        'alert'
+      )
+    })
+  })
+
+  it('has no aria-invalid or aria-describedby before submit', () => {
+    renderWithProviders(<DonorForm onSubmit={vi.fn()} submitLabel="Guardar" />)
+
+    const fullNameInput = screen.getByLabelText('Nombre completo')
+    expect(fullNameInput).toHaveAttribute('aria-invalid', 'false')
+    expect(fullNameInput).not.toHaveAttribute('aria-describedby')
+
+    const dniNieInput = screen.getByLabelText('DNI/NIE')
+    expect(dniNieInput).toHaveAttribute('aria-invalid', 'false')
+    expect(dniNieInput).not.toHaveAttribute('aria-describedby')
+  })
+
   it('calls onSubmit with valid data', async () => {
     const user = userEvent.setup()
     const onSubmit = vi.fn()

--- a/src/features/donors/donor-form.tsx
+++ b/src/features/donors/donor-form.tsx
@@ -41,9 +41,18 @@ export function DonorForm({
       <div className="grid gap-4 sm:grid-cols-2">
         <div className="space-y-2">
           <Label htmlFor="fullName">{t('donors.fullName')}</Label>
-          <Input id="fullName" {...register('fullName')} />
+          <Input
+            id="fullName"
+            aria-invalid={!!errors.fullName}
+            aria-describedby={errors.fullName ? 'fullName-error' : undefined}
+            {...register('fullName')}
+          />
           {errors.fullName && (
-            <p className="text-sm text-destructive">
+            <p
+              id="fullName-error"
+              role="alert"
+              className="text-sm text-destructive"
+            >
               {errors.fullName.message}
             </p>
           )}
@@ -51,17 +60,40 @@ export function DonorForm({
 
         <div className="space-y-2">
           <Label htmlFor="dniNie">{t('donors.dniNie')}</Label>
-          <Input id="dniNie" {...register('dniNie')} />
+          <Input
+            id="dniNie"
+            aria-invalid={!!errors.dniNie}
+            aria-describedby={errors.dniNie ? 'dniNie-error' : undefined}
+            {...register('dniNie')}
+          />
           {errors.dniNie && (
-            <p className="text-sm text-destructive">{errors.dniNie.message}</p>
+            <p
+              id="dniNie-error"
+              role="alert"
+              className="text-sm text-destructive"
+            >
+              {errors.dniNie.message}
+            </p>
           )}
         </div>
 
         <div className="space-y-2">
           <Label htmlFor="email">{t('donors.emailOptional')}</Label>
-          <Input id="email" type="email" {...register('email')} />
+          <Input
+            id="email"
+            type="email"
+            aria-invalid={!!errors.email}
+            aria-describedby={errors.email ? 'email-error' : undefined}
+            {...register('email')}
+          />
           {errors.email && (
-            <p className="text-sm text-destructive">{errors.email.message}</p>
+            <p
+              id="email-error"
+              role="alert"
+              className="text-sm text-destructive"
+            >
+              {errors.email.message}
+            </p>
           )}
         </div>
 

--- a/src/features/expenses/expense-form.test.tsx
+++ b/src/features/expenses/expense-form.test.tsx
@@ -76,4 +76,66 @@ describe('ExpenseForm', () => {
 
     expect(screen.getByRole('button', { name: 'Cargando...' })).toBeDisabled()
   })
+
+  it('sets aria-invalid and aria-describedby on invalid submit', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(
+      <ExpenseForm onSubmit={onSubmit} submitLabel="Guardar" />
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Guardar' }))
+
+    const amountInput = screen.getByLabelText('Monto')
+    expect(amountInput).toHaveAttribute('aria-invalid', 'true')
+    expect(amountInput).toHaveAttribute('aria-describedby', 'amount-error')
+    expect(document.getElementById('amount-error')).toHaveAttribute(
+      'role',
+      'alert'
+    )
+
+    const dateInput = screen.getByLabelText('Fecha')
+    expect(dateInput).toHaveAttribute('aria-invalid', 'true')
+    expect(dateInput).toHaveAttribute('aria-describedby', 'expenseDate-error')
+    expect(document.getElementById('expenseDate-error')).toHaveAttribute(
+      'role',
+      'alert'
+    )
+
+    const descriptionInput = screen.getByLabelText('Descripción')
+    expect(descriptionInput).toHaveAttribute('aria-invalid', 'true')
+    expect(descriptionInput).toHaveAttribute(
+      'aria-describedby',
+      'description-error'
+    )
+    expect(document.getElementById('description-error')).toHaveAttribute(
+      'role',
+      'alert'
+    )
+  })
+
+  it('has no aria-invalid or aria-describedby when no errors', () => {
+    renderWithProviders(
+      <ExpenseForm
+        defaultValues={{
+          amount: 100,
+          expenseDate: '2026-04-10',
+          description: 'Test',
+        }}
+        onSubmit={onSubmit}
+        submitLabel="Guardar"
+      />
+    )
+
+    const amountInput = screen.getByLabelText('Monto')
+    expect(amountInput).toHaveAttribute('aria-invalid', 'false')
+    expect(amountInput).not.toHaveAttribute('aria-describedby')
+
+    const dateInput = screen.getByLabelText('Fecha')
+    expect(dateInput).toHaveAttribute('aria-invalid', 'false')
+    expect(dateInput).not.toHaveAttribute('aria-describedby')
+
+    const descriptionInput = screen.getByLabelText('Descripción')
+    expect(descriptionInput).toHaveAttribute('aria-invalid', 'false')
+    expect(descriptionInput).not.toHaveAttribute('aria-describedby')
+  })
 })

--- a/src/features/expenses/expense-form.tsx
+++ b/src/features/expenses/expense-form.tsx
@@ -62,25 +62,45 @@ export function ExpenseForm({
             type="number"
             step="0.01"
             min="0.01"
+            aria-invalid={!!errors.amount}
+            aria-describedby={errors.amount ? 'amount-error' : undefined}
             {...register('amount', { valueAsNumber: true })}
           />
           {errors.amount && (
-            <p className="text-sm text-destructive">{errors.amount.message}</p>
+            <p
+              id="amount-error"
+              role="alert"
+              className="text-sm text-destructive"
+            >
+              {errors.amount.message}
+            </p>
           )}
         </div>
 
         <div className="space-y-2">
           <Label htmlFor="expenseDate">{t('expenses.date')}</Label>
-          <Input id="expenseDate" type="date" {...register('expenseDate')} />
+          <Input
+            id="expenseDate"
+            type="date"
+            aria-invalid={!!errors.expenseDate}
+            aria-describedby={
+              errors.expenseDate ? 'expenseDate-error' : undefined
+            }
+            {...register('expenseDate')}
+          />
           {errors.expenseDate && (
-            <p className="text-sm text-destructive">
+            <p
+              id="expenseDate-error"
+              role="alert"
+              className="text-sm text-destructive"
+            >
               {errors.expenseDate.message}
             </p>
           )}
         </div>
 
         <div className="space-y-2">
-          <Label>{t('expenses.category')}</Label>
+          <Label htmlFor="category">{t('expenses.category')}</Label>
           <Controller
             control={control}
             name="category"
@@ -91,7 +111,13 @@ export function ExpenseForm({
                 }
                 onValueChange={field.onChange}
               >
-                <SelectTrigger>
+                <SelectTrigger
+                  id="category"
+                  aria-invalid={!!errors.category}
+                  aria-describedby={
+                    errors.category ? 'category-error' : undefined
+                  }
+                >
                   <SelectValue placeholder={t('expenses.selectCategory')} />
                 </SelectTrigger>
                 <SelectContent>
@@ -105,14 +131,18 @@ export function ExpenseForm({
             )}
           />
           {errors.category && (
-            <p className="text-sm text-destructive">
+            <p
+              id="category-error"
+              role="alert"
+              className="text-sm text-destructive"
+            >
               {errors.category.message}
             </p>
           )}
         </div>
 
         <div className="space-y-2">
-          <Label>{t('expenses.paymentMethod')}</Label>
+          <Label htmlFor="paymentMethod">{t('expenses.paymentMethod')}</Label>
           <Controller
             control={control}
             name="paymentMethod"
@@ -123,7 +153,13 @@ export function ExpenseForm({
                 }
                 onValueChange={field.onChange}
               >
-                <SelectTrigger>
+                <SelectTrigger
+                  id="paymentMethod"
+                  aria-invalid={!!errors.paymentMethod}
+                  aria-describedby={
+                    errors.paymentMethod ? 'paymentMethod-error' : undefined
+                  }
+                >
                   <SelectValue placeholder={t('expenses.selectPayment')} />
                 </SelectTrigger>
                 <SelectContent>
@@ -137,7 +173,11 @@ export function ExpenseForm({
             )}
           />
           {errors.paymentMethod && (
-            <p className="text-sm text-destructive">
+            <p
+              id="paymentMethod-error"
+              role="alert"
+              className="text-sm text-destructive"
+            >
               {errors.paymentMethod.message}
             </p>
           )}
@@ -146,9 +186,20 @@ export function ExpenseForm({
 
       <div className="space-y-2">
         <Label htmlFor="description">{t('expenses.description')}</Label>
-        <Textarea id="description" {...register('description')} />
+        <Textarea
+          id="description"
+          aria-invalid={!!errors.description}
+          aria-describedby={
+            errors.description ? 'description-error' : undefined
+          }
+          {...register('description')}
+        />
         {errors.description && (
-          <p className="text-sm text-destructive">
+          <p
+            id="description-error"
+            role="alert"
+            className="text-sm text-destructive"
+          >
             {errors.description.message}
           </p>
         )}

--- a/src/features/settings/change-password-page.test.tsx
+++ b/src/features/settings/change-password-page.test.tsx
@@ -79,6 +79,31 @@ describe('ChangePasswordPage', () => {
     })
   })
 
+  it('sets aria-invalid and aria-describedby on invalid fields after submit', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await user.click(screen.getByRole('button', { name: 'Guardar' }))
+    await waitFor(() => {
+      const input = screen.getByLabelText('Contraseña actual')
+      expect(input).toHaveAttribute('aria-invalid', 'true')
+      expect(input).toHaveAttribute(
+        'aria-describedby',
+        'currentPassword-error'
+      )
+      expect(document.getElementById('currentPassword-error')).toHaveAttribute(
+        'role',
+        'alert'
+      )
+    })
+  })
+
+  it('clears aria-invalid and aria-describedby when field has no error', () => {
+    renderPage()
+    const input = screen.getByLabelText('Contraseña actual')
+    expect(input).toHaveAttribute('aria-invalid', 'false')
+    expect(input).not.toHaveAttribute('aria-describedby')
+  })
+
   it('shows error alert when current password is wrong', async () => {
     const user = userEvent.setup()
     renderPage()

--- a/src/features/settings/change-password-page.test.tsx
+++ b/src/features/settings/change-password-page.test.tsx
@@ -86,10 +86,7 @@ describe('ChangePasswordPage', () => {
     await waitFor(() => {
       const input = screen.getByLabelText('Contraseña actual')
       expect(input).toHaveAttribute('aria-invalid', 'true')
-      expect(input).toHaveAttribute(
-        'aria-describedby',
-        'currentPassword-error'
-      )
+      expect(input).toHaveAttribute('aria-describedby', 'currentPassword-error')
       expect(document.getElementById('currentPassword-error')).toHaveAttribute(
         'role',
         'alert'

--- a/src/features/settings/change-password-page.tsx
+++ b/src/features/settings/change-password-page.tsx
@@ -85,10 +85,18 @@ export function ChangePasswordPage() {
                 id="currentPassword"
                 type="password"
                 autoComplete="current-password"
+                aria-invalid={!!errors.currentPassword}
+                aria-describedby={
+                  errors.currentPassword ? 'currentPassword-error' : undefined
+                }
                 {...register('currentPassword')}
               />
               {errors.currentPassword && (
-                <p className="text-sm text-destructive">
+                <p
+                  id="currentPassword-error"
+                  role="alert"
+                  className="text-sm text-destructive"
+                >
                   {errors.currentPassword.message}
                 </p>
               )}
@@ -100,10 +108,18 @@ export function ChangePasswordPage() {
                 id="newPassword"
                 type="password"
                 autoComplete="new-password"
+                aria-invalid={!!errors.newPassword}
+                aria-describedby={
+                  errors.newPassword ? 'newPassword-error' : undefined
+                }
                 {...register('newPassword')}
               />
               {errors.newPassword && (
-                <p className="text-sm text-destructive">
+                <p
+                  id="newPassword-error"
+                  role="alert"
+                  className="text-sm text-destructive"
+                >
                   {errors.newPassword.message}
                 </p>
               )}
@@ -117,10 +133,18 @@ export function ChangePasswordPage() {
                 id="confirmPassword"
                 type="password"
                 autoComplete="new-password"
+                aria-invalid={!!errors.confirmPassword}
+                aria-describedby={
+                  errors.confirmPassword ? 'confirmPassword-error' : undefined
+                }
                 {...register('confirmPassword')}
               />
               {errors.confirmPassword && (
-                <p className="text-sm text-destructive">
+                <p
+                  id="confirmPassword-error"
+                  role="alert"
+                  className="text-sm text-destructive"
+                >
                   {errors.confirmPassword.message}
                 </p>
               )}

--- a/src/features/users/user-form.test.tsx
+++ b/src/features/users/user-form.test.tsx
@@ -57,15 +57,30 @@ describe('UserForm — create mode', () => {
     await waitFor(() => {
       const usernameInput = screen.getByLabelText('Nombre de usuario')
       expect(usernameInput).toHaveAttribute('aria-invalid', 'true')
-      expect(usernameInput).toHaveAttribute('aria-describedby', 'username-error')
-      expect(document.getElementById('username-error')).toHaveAttribute('role', 'alert')
+      expect(usernameInput).toHaveAttribute(
+        'aria-describedby',
+        'username-error'
+      )
+      expect(document.getElementById('username-error')).toHaveAttribute(
+        'role',
+        'alert'
+      )
 
       const passwordInput = screen.getByLabelText('Contraseña')
       expect(passwordInput).toHaveAttribute('aria-invalid', 'true')
-      expect(passwordInput).toHaveAttribute('aria-describedby', 'password-error')
-      expect(document.getElementById('password-error')).toHaveAttribute('role', 'alert')
+      expect(passwordInput).toHaveAttribute(
+        'aria-describedby',
+        'password-error'
+      )
+      expect(document.getElementById('password-error')).toHaveAttribute(
+        'role',
+        'alert'
+      )
 
-      expect(document.getElementById('roles-error')).toHaveAttribute('role', 'alert')
+      expect(document.getElementById('roles-error')).toHaveAttribute(
+        'role',
+        'alert'
+      )
     })
   })
 

--- a/src/features/users/user-form.test.tsx
+++ b/src/features/users/user-form.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { renderWithProviders } from '@/test/test-utils'
@@ -44,6 +44,43 @@ describe('UserForm — create mode', () => {
       screen.getByText('La contraseña debe tener al menos 8 caracteres')
     ).toBeInTheDocument()
     expect(screen.getByText('Seleccione al menos un rol')).toBeInTheDocument()
+  })
+
+  it('sets aria-invalid and aria-describedby on invalid submit', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(
+      <UserForm mode="create" onSubmit={vi.fn()} submitLabel="Guardar" />
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Guardar' }))
+
+    await waitFor(() => {
+      const usernameInput = screen.getByLabelText('Nombre de usuario')
+      expect(usernameInput).toHaveAttribute('aria-invalid', 'true')
+      expect(usernameInput).toHaveAttribute('aria-describedby', 'username-error')
+      expect(document.getElementById('username-error')).toHaveAttribute('role', 'alert')
+
+      const passwordInput = screen.getByLabelText('Contraseña')
+      expect(passwordInput).toHaveAttribute('aria-invalid', 'true')
+      expect(passwordInput).toHaveAttribute('aria-describedby', 'password-error')
+      expect(document.getElementById('password-error')).toHaveAttribute('role', 'alert')
+
+      expect(document.getElementById('roles-error')).toHaveAttribute('role', 'alert')
+    })
+  })
+
+  it('has no aria-describedby before submit', () => {
+    renderWithProviders(
+      <UserForm mode="create" onSubmit={vi.fn()} submitLabel="Guardar" />
+    )
+
+    const usernameInput = screen.getByLabelText('Nombre de usuario')
+    expect(usernameInput).toHaveAttribute('aria-invalid', 'false')
+    expect(usernameInput).not.toHaveAttribute('aria-describedby')
+
+    const passwordInput = screen.getByLabelText('Contraseña')
+    expect(passwordInput).toHaveAttribute('aria-invalid', 'false')
+    expect(passwordInput).not.toHaveAttribute('aria-describedby')
   })
 
   it('shows loading state when submitting', () => {

--- a/src/features/users/user-form.tsx
+++ b/src/features/users/user-form.tsx
@@ -67,9 +67,14 @@ export function UserForm({
       <div className="grid gap-4 sm:grid-cols-2">
         <div className="space-y-2">
           <Label htmlFor="username">{t('users.username')}</Label>
-          <Input id="username" {...register('username')} />
+          <Input
+            id="username"
+            aria-invalid={!!errors.username}
+            aria-describedby={errors.username ? 'username-error' : undefined}
+            {...register('username')}
+          />
           {errors.username && (
-            <p className="text-sm text-destructive">
+            <p id="username-error" role="alert" className="text-sm text-destructive">
               {errors.username.message as string}
             </p>
           )}
@@ -81,9 +86,15 @@ export function UserForm({
               ? t('users.password')
               : t('users.passwordOptional')}
           </Label>
-          <Input id="password" type="password" {...register('password')} />
+          <Input
+            id="password"
+            type="password"
+            aria-invalid={!!errors.password}
+            aria-describedby={errors.password ? 'password-error' : undefined}
+            {...register('password')}
+          />
           {errors.password && (
-            <p className="text-sm text-destructive">
+            <p id="password-error" role="alert" className="text-sm text-destructive">
               {errors.password.message as string}
             </p>
           )}
@@ -98,7 +109,10 @@ export function UserForm({
           render={({ field }) => {
             const value = (field.value ?? []) as string[]
             return (
-              <div className="flex flex-wrap gap-3">
+              <div
+                className="flex flex-wrap gap-3"
+                aria-describedby={errors.roles ? 'roles-error' : undefined}
+              >
                 {userRoles.map((role) => (
                   <label key={role} className="flex items-center gap-2 text-sm">
                     <input
@@ -111,6 +125,7 @@ export function UserForm({
                             : [...value, role]
                         )
                       }
+                      aria-invalid={!!errors.roles}
                       className="size-4 rounded border-input"
                     />
                     {t(`users.roleNames.${role}`)}
@@ -121,7 +136,7 @@ export function UserForm({
           }}
         />
         {errors.roles && (
-          <p className="text-sm text-destructive">
+          <p id="roles-error" role="alert" className="text-sm text-destructive">
             {errors.roles.message as string}
           </p>
         )}

--- a/src/features/users/user-form.tsx
+++ b/src/features/users/user-form.tsx
@@ -74,7 +74,11 @@ export function UserForm({
             {...register('username')}
           />
           {errors.username && (
-            <p id="username-error" role="alert" className="text-sm text-destructive">
+            <p
+              id="username-error"
+              role="alert"
+              className="text-sm text-destructive"
+            >
               {errors.username.message as string}
             </p>
           )}
@@ -94,7 +98,11 @@ export function UserForm({
             {...register('password')}
           />
           {errors.password && (
-            <p id="password-error" role="alert" className="text-sm text-destructive">
+            <p
+              id="password-error"
+              role="alert"
+              className="text-sm text-destructive"
+            >
               {errors.password.message as string}
             </p>
           )}


### PR DESCRIPTION
## Summary

- Wires `aria-invalid`, `aria-describedby` on every form input across all five forms (donation, donor, expense, user, change password)
- Adds stable `id` + `role="alert"` to every error paragraph so screen readers announce validation errors on submit
- Adds `htmlFor` on Select labels (donation, expense forms) where missing
- 10 new unit tests (2 per form) covering invalid-submit state and clean/no-error state

## Test plan

- [ ] Run `npm run test` — all tests pass
- [ ] Submit any form with empty/invalid fields → screen reader announces errors (verify with VoiceOver/NVDA or axe DevTools)
- [ ] Fix errors and resubmit → `aria-invalid` clears, `aria-describedby` absent

Relates #20 