### PR TITLE
feat(a11y): Phase 3 — List page fixes — Tables and edit links

### DIFF
--- a/src/features/donations/donations-page.test.tsx
+++ b/src/features/donations/donations-page.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from '@testing-library/react'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { renderWithProviders } from '@/test/test-utils'
@@ -90,5 +90,44 @@ describe('DonationsPage', () => {
 
     const editLinks = screen.getAllByRole('link')
     expect(editLinks.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('toggles sort with Enter key on sortable header', async () => {
+    renderWithProviders(<DonationsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Juan Pérez')).toBeInTheDocument()
+    })
+    fireEvent.keyDown(screen.getByRole('columnheader', { name: /Fecha/ }), {
+      key: 'Enter',
+    })
+    await waitFor(() => {
+      expect(
+        screen.getByRole('columnheader', { name: /Fecha/ })
+      ).toHaveAttribute('aria-sort', 'ascending')
+    })
+  })
+
+  it('toggles sort with Space key on sortable header', async () => {
+    renderWithProviders(<DonationsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Juan Pérez')).toBeInTheDocument()
+    })
+    fireEvent.keyDown(screen.getByRole('columnheader', { name: /Fecha/ }), {
+      key: ' ',
+    })
+    await waitFor(() => {
+      expect(
+        screen.getByRole('columnheader', { name: /Fecha/ })
+      ).toHaveAttribute('aria-sort', 'ascending')
+    })
+  })
+
+  it('edit links have descriptive aria-labels', async () => {
+    renderWithProviders(<DonationsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Juan Pérez')).toBeInTheDocument()
+    })
+    const editLinks = screen.getAllByRole('link', { name: /Editar donación/ })
+    expect(editLinks[0]).toBeInTheDocument()
   })
 })

--- a/src/features/donations/donations-page.tsx
+++ b/src/features/donations/donations-page.tsx
@@ -6,7 +6,7 @@ import { Link, useNavigate } from 'react-router'
 import { DateRangePicker } from '@/components/date-range-picker'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
+import { Button, buttonVariants } from '@/components/ui/button'
 import {
   Table,
   TableBody,
@@ -62,6 +62,12 @@ export function DonationsPage() {
     return currentDir === 'asc' ? ' ↑' : ' ↓'
   }
 
+  function ariaSort(field: string): 'ascending' | 'descending' | 'none' {
+    const [currentField, currentDir] = sort.split(',')
+    if (currentField !== field) return 'none'
+    return currentDir === 'asc' ? 'ascending' : 'descending'
+  }
+
   return (
     <div className="space-y-4">
       <div className="flex flex-wrap items-center justify-between gap-4">
@@ -108,16 +114,34 @@ export function DonationsPage() {
                 <TableHead
                   className="cursor-pointer"
                   onClick={() => toggleSort('donationDate')}
+                  tabIndex={0}
+                  aria-sort={ariaSort('donationDate')}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault()
+                      toggleSort('donationDate')
+                    }
+                  }}
                 >
                   {t('donations.date')}
-                  {sortIndicator('donationDate')}
+                  <span aria-hidden="true">
+                    {sortIndicator('donationDate')}
+                  </span>
                 </TableHead>
                 <TableHead
                   className="cursor-pointer"
                   onClick={() => toggleSort('amount')}
+                  tabIndex={0}
+                  aria-sort={ariaSort('amount')}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault()
+                      toggleSort('amount')
+                    }
+                  }}
                 >
                   {t('donations.amount')}
-                  {sortIndicator('amount')}
+                  <span aria-hidden="true">{sortIndicator('amount')}</span>
                 </TableHead>
                 <TableHead>{t('donations.type')}</TableHead>
                 <TableHead>{t('donations.paymentMethod')}</TableHead>
@@ -142,10 +166,17 @@ export function DonationsPage() {
                   </TableCell>
                   <TableCell>{d.donorName ?? t('donations.noDonor')}</TableCell>
                   <TableCell>
-                    <Link to={`/donations/${d.id}/edit`}>
-                      <Button variant="ghost" size="icon">
-                        <Pencil size={14} />
-                      </Button>
+                    <Link
+                      to={`/donations/${d.id}/edit`}
+                      className={buttonVariants({
+                        variant: 'ghost',
+                        size: 'icon',
+                      })}
+                      aria-label={t('donations.editLabel', {
+                        date: dayjs(d.donationDate).format('DD/MM/YYYY'),
+                      })}
+                    >
+                      <Pencil size={14} aria-hidden="true" />
                     </Link>
                   </TableCell>
                 </TableRow>

--- a/src/features/donors/donors-page.test.tsx
+++ b/src/features/donors/donors-page.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from '@testing-library/react'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { renderWithProviders } from '@/test/test-utils'
@@ -89,5 +89,46 @@ describe('DonorsPage', () => {
 
     const editLinks = screen.getAllByRole('link')
     expect(editLinks.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('toggles sort with Enter key on sortable header', async () => {
+    renderWithProviders(<DonorsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Juan Pérez')).toBeInTheDocument()
+    })
+    fireEvent.keyDown(
+      screen.getByRole('columnheader', { name: /Nombre completo/ }),
+      { key: 'Enter' }
+    )
+    await waitFor(() => {
+      expect(
+        screen.getByRole('columnheader', { name: /Nombre completo/ })
+      ).toHaveAttribute('aria-sort', 'descending')
+    })
+  })
+
+  it('toggles sort with Space key on sortable header', async () => {
+    renderWithProviders(<DonorsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Juan Pérez')).toBeInTheDocument()
+    })
+    fireEvent.keyDown(
+      screen.getByRole('columnheader', { name: /Nombre completo/ }),
+      { key: ' ' }
+    )
+    await waitFor(() => {
+      expect(
+        screen.getByRole('columnheader', { name: /Nombre completo/ })
+      ).toHaveAttribute('aria-sort', 'descending')
+    })
+  })
+
+  it('edit links have descriptive aria-labels', async () => {
+    renderWithProviders(<DonorsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Juan Pérez')).toBeInTheDocument()
+    })
+    const editLink = screen.getAllByRole('link', { name: /Editar donante/ })
+    expect(editLink[0]).toBeInTheDocument()
   })
 })

--- a/src/features/donors/donors-page.tsx
+++ b/src/features/donors/donors-page.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { Link, useNavigate } from 'react-router'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
+import { Button, buttonVariants } from '@/components/ui/button'
 import {
   Table,
   TableBody,
@@ -37,6 +37,12 @@ export function DonorsPage() {
     const [currentField, currentDir] = sort.split(',')
     if (currentField !== field) return ''
     return currentDir === 'asc' ? ' ↑' : ' ↓'
+  }
+
+  function ariaSort(field: string): 'ascending' | 'descending' | 'none' {
+    const [currentField, currentDir] = sort.split(',')
+    if (currentField !== field) return 'none'
+    return currentDir === 'asc' ? 'ascending' : 'descending'
   }
 
   return (
@@ -75,9 +81,17 @@ export function DonorsPage() {
                 <TableHead
                   className="cursor-pointer"
                   onClick={() => toggleSort('fullName')}
+                  tabIndex={0}
+                  aria-sort={ariaSort('fullName')}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault()
+                      toggleSort('fullName')
+                    }
+                  }}
                 >
                   {t('donors.fullName')}
-                  {sortIndicator('fullName')}
+                  <span aria-hidden="true">{sortIndicator('fullName')}</span>
                 </TableHead>
                 <TableHead>{t('donors.dniNie')}</TableHead>
                 <TableHead>{t('donors.email')}</TableHead>
@@ -101,10 +115,17 @@ export function DonorsPage() {
                     </Badge>
                   </TableCell>
                   <TableCell>
-                    <Link to={`/donors/${donor.id}/edit`}>
-                      <Button variant="ghost" size="icon">
-                        <Pencil size={14} />
-                      </Button>
+                    <Link
+                      to={`/donors/${donor.id}/edit`}
+                      className={buttonVariants({
+                        variant: 'ghost',
+                        size: 'icon',
+                      })}
+                      aria-label={t('donors.editLabel', {
+                        name: donor.fullName,
+                      })}
+                    >
+                      <Pencil size={14} aria-hidden="true" />
                     </Link>
                   </TableCell>
                 </TableRow>

--- a/src/features/expenses/expenses-page.test.tsx
+++ b/src/features/expenses/expenses-page.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from '@testing-library/react'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { renderWithProviders } from '@/test/test-utils'
@@ -78,5 +78,44 @@ describe('ExpensesPage', () => {
 
     const editLinks = screen.getAllByRole('link')
     expect(editLinks.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('toggles sort with Enter key on sortable header', async () => {
+    renderWithProviders(<ExpensesPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Alquiler local abril')).toBeInTheDocument()
+    })
+    fireEvent.keyDown(screen.getByRole('columnheader', { name: /Fecha/ }), {
+      key: 'Enter',
+    })
+    await waitFor(() => {
+      expect(
+        screen.getByRole('columnheader', { name: /Fecha/ })
+      ).toHaveAttribute('aria-sort', 'ascending')
+    })
+  })
+
+  it('toggles sort with Space key on sortable header', async () => {
+    renderWithProviders(<ExpensesPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Alquiler local abril')).toBeInTheDocument()
+    })
+    fireEvent.keyDown(screen.getByRole('columnheader', { name: /Fecha/ }), {
+      key: ' ',
+    })
+    await waitFor(() => {
+      expect(
+        screen.getByRole('columnheader', { name: /Fecha/ })
+      ).toHaveAttribute('aria-sort', 'ascending')
+    })
+  })
+
+  it('edit links have descriptive aria-labels', async () => {
+    renderWithProviders(<ExpensesPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Alquiler local abril')).toBeInTheDocument()
+    })
+    const editLinks = screen.getAllByRole('link', { name: /Editar gasto/ })
+    expect(editLinks[0]).toBeInTheDocument()
   })
 })

--- a/src/features/expenses/expenses-page.tsx
+++ b/src/features/expenses/expenses-page.tsx
@@ -6,7 +6,7 @@ import { Link, useNavigate } from 'react-router'
 import { DateRangePicker } from '@/components/date-range-picker'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
+import { Button, buttonVariants } from '@/components/ui/button'
 import {
   Table,
   TableBody,
@@ -62,6 +62,12 @@ export function ExpensesPage() {
     return currentDir === 'asc' ? ' ↑' : ' ↓'
   }
 
+  function ariaSort(field: string): 'ascending' | 'descending' | 'none' {
+    const [currentField, currentDir] = sort.split(',')
+    if (currentField !== field) return 'none'
+    return currentDir === 'asc' ? 'ascending' : 'descending'
+  }
+
   return (
     <div className="space-y-4">
       <div className="flex flex-wrap items-center justify-between gap-4">
@@ -108,16 +114,32 @@ export function ExpensesPage() {
                 <TableHead
                   className="cursor-pointer"
                   onClick={() => toggleSort('expenseDate')}
+                  tabIndex={0}
+                  aria-sort={ariaSort('expenseDate')}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault()
+                      toggleSort('expenseDate')
+                    }
+                  }}
                 >
                   {t('expenses.date')}
-                  {sortIndicator('expenseDate')}
+                  <span aria-hidden="true">{sortIndicator('expenseDate')}</span>
                 </TableHead>
                 <TableHead
                   className="cursor-pointer"
                   onClick={() => toggleSort('amount')}
+                  tabIndex={0}
+                  aria-sort={ariaSort('amount')}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault()
+                      toggleSort('amount')
+                    }
+                  }}
                 >
                   {t('expenses.amount')}
-                  {sortIndicator('amount')}
+                  <span aria-hidden="true">{sortIndicator('amount')}</span>
                 </TableHead>
                 <TableHead>{t('expenses.category')}</TableHead>
                 <TableHead>{t('expenses.description')}</TableHead>
@@ -144,10 +166,17 @@ export function ExpensesPage() {
                     {t(`expenses.paymentMethods.${e.paymentMethod}`)}
                   </TableCell>
                   <TableCell>
-                    <Link to={`/expenses/${e.id}/edit`}>
-                      <Button variant="ghost" size="icon">
-                        <Pencil size={14} />
-                      </Button>
+                    <Link
+                      to={`/expenses/${e.id}/edit`}
+                      className={buttonVariants({
+                        variant: 'ghost',
+                        size: 'icon',
+                      })}
+                      aria-label={t('expenses.editLabel', {
+                        date: dayjs(e.expenseDate).format('DD/MM/YYYY'),
+                      })}
+                    >
+                      <Pencil size={14} aria-hidden="true" />
                     </Link>
                   </TableCell>
                 </TableRow>

--- a/src/features/users/users-page.test.tsx
+++ b/src/features/users/users-page.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from '@testing-library/react'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { renderWithProviders } from '@/test/test-utils'
@@ -90,5 +90,46 @@ describe('UsersPage', () => {
 
     const editLinks = screen.getAllByRole('link')
     expect(editLinks.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('toggles sort with Enter key on sortable header', async () => {
+    renderWithProviders(<UsersPage />)
+    await waitFor(() => {
+      expect(screen.getByText('admin')).toBeInTheDocument()
+    })
+    fireEvent.keyDown(
+      screen.getByRole('columnheader', { name: /Nombre de usuario/ }),
+      { key: 'Enter' }
+    )
+    await waitFor(() => {
+      expect(
+        screen.getByRole('columnheader', { name: /Nombre de usuario/ })
+      ).toHaveAttribute('aria-sort', 'descending')
+    })
+  })
+
+  it('toggles sort with Space key on sortable header', async () => {
+    renderWithProviders(<UsersPage />)
+    await waitFor(() => {
+      expect(screen.getByText('admin')).toBeInTheDocument()
+    })
+    fireEvent.keyDown(
+      screen.getByRole('columnheader', { name: /Nombre de usuario/ }),
+      { key: ' ' }
+    )
+    await waitFor(() => {
+      expect(
+        screen.getByRole('columnheader', { name: /Nombre de usuario/ })
+      ).toHaveAttribute('aria-sort', 'descending')
+    })
+  })
+
+  it('edit links have descriptive aria-labels', async () => {
+    renderWithProviders(<UsersPage />)
+    await waitFor(() => {
+      expect(screen.getByText('admin')).toBeInTheDocument()
+    })
+    const editLink = screen.getAllByRole('link', { name: /Editar usuario/ })
+    expect(editLink[0]).toBeInTheDocument()
   })
 })

--- a/src/features/users/users-page.tsx
+++ b/src/features/users/users-page.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { Link, useNavigate } from 'react-router'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
+import { Button, buttonVariants } from '@/components/ui/button'
 import {
   Table,
   TableBody,
@@ -43,6 +43,12 @@ export function UsersPage() {
     return currentDir === 'asc' ? ' ↑' : ' ↓'
   }
 
+  function ariaSort(field: string): 'ascending' | 'descending' | 'none' {
+    const [currentField, currentDir] = sort.split(',')
+    if (currentField !== field) return 'none'
+    return currentDir === 'asc' ? 'ascending' : 'descending'
+  }
+
   return (
     <div className="space-y-4">
       <div className="flex flex-wrap items-center justify-between gap-4">
@@ -79,9 +85,17 @@ export function UsersPage() {
                 <TableHead
                   className="cursor-pointer"
                   onClick={() => toggleSort('username')}
+                  tabIndex={0}
+                  aria-sort={ariaSort('username')}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault()
+                      toggleSort('username')
+                    }
+                  }}
                 >
                   {t('users.username')}
-                  {sortIndicator('username')}
+                  <span aria-hidden="true">{sortIndicator('username')}</span>
                 </TableHead>
                 <TableHead>{t('users.roles')}</TableHead>
                 <TableHead>{t('users.status')}</TableHead>
@@ -107,10 +121,17 @@ export function UsersPage() {
                     </Badge>
                   </TableCell>
                   <TableCell>
-                    <Link to={`/users/${u.id}/edit`}>
-                      <Button variant="ghost" size="icon">
-                        <Pencil size={14} />
-                      </Button>
+                    <Link
+                      to={`/users/${u.id}/edit`}
+                      className={buttonVariants({
+                        variant: 'ghost',
+                        size: 'icon',
+                      })}
+                      aria-label={t('users.editLabel', {
+                        username: u.username,
+                      })}
+                    >
+                      <Pencil size={14} aria-hidden="true" />
                     </Link>
                   </TableCell>
                 </TableRow>

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -79,7 +79,8 @@
     "next": "Siguiente",
     "selectType": "Seleccione tipo",
     "selectPayment": "Seleccione m\u00e9todo",
-    "selectDonor": "Seleccione donante"
+    "selectDonor": "Seleccione donante",
+    "editLabel": "Editar donación del {{date}}"
   },
   "donors": {
     "title": "Donantes",
@@ -105,7 +106,8 @@
     "empty": "No hay donantes registrados",
     "page": "Página {{page}} de {{total}}",
     "previous": "Anterior",
-    "next": "Siguiente"
+    "next": "Siguiente",
+    "editLabel": "Editar donante {{name}}"
   },
   "expenses": {
     "title": "Gastos",
@@ -142,7 +144,8 @@
     "empty": "No hay gastos registrados",
     "page": "Página {{page}} de {{total}}",
     "previous": "Anterior",
-    "next": "Siguiente"
+    "next": "Siguiente",
+    "editLabel": "Editar gasto del {{date}}"
   },
   "users": {
     "title": "Usuarios",
@@ -171,7 +174,8 @@
     "page": "Página {{page}} de {{total}}",
     "previous": "Anterior",
     "next": "Siguiente",
-    "noAccess": "No tiene permisos para acceder a esta sección"
+    "noAccess": "No tiene permisos para acceder a esta sección",
+    "editLabel": "Editar usuario {{username}}"
   },
   "reports": {
     "title": "Reportes",


### PR DESCRIPTION
## Summary

- Edit link: replaced <Link><Button> with single <Link className={buttonVariants(...)} aria-label={t('*.editLabel', {context})}>
- Sortable TableHead: tabIndex={0}, aria-sort, onKeyDown (Enter/Space), sort indicator wrapped in <span aria-hidden="true">
- ariaSort() helper added to each page
- 3 new unit tests per page: Enter key sort, Space key sort, edit link aria-label
- Added editLabel i18n keys to es.json for all 4 features

## Related

- Closes #21 
- PRD: `docs/PRD-accessibility.md`
- Plan: `docs/plans/accessibility.md`