### PR TITLE
feat(a11y): Phase 4 — sidebar landmark labels and Reports tab ARIA

### DIFF
--- a/src/features/reports/reports-page.test.tsx
+++ b/src/features/reports/reports-page.test.tsx
@@ -82,4 +82,35 @@ describe('ReportsPage', () => {
     })
     expect(expensesTab.getAttribute('aria-selected')).toBe('false')
   })
+
+  it('tab buttons have id and aria-controls pointing to panel', () => {
+    renderPage()
+    const donationsTab = screen.getByRole('tab', {
+      name: 'Resumen de donaciones',
+    })
+    expect(donationsTab).toHaveAttribute('id', 'tab-donations')
+    expect(donationsTab).toHaveAttribute('aria-controls', 'panel-donations')
+
+    const expensesTab = screen.getByRole('tab', { name: 'Resumen de gastos' })
+    expect(expensesTab).toHaveAttribute('id', 'tab-expenses')
+    expect(expensesTab).toHaveAttribute('aria-controls', 'panel-expenses')
+  })
+
+  it('active panel has tabpanel role wired to its tab', () => {
+    renderPage()
+    const panel = screen.getByRole('tabpanel')
+    expect(panel).toHaveAttribute('id', 'panel-donations')
+    expect(panel).toHaveAttribute('aria-labelledby', 'tab-donations')
+    expect(panel).toHaveAttribute('tabindex', '0')
+  })
+
+  it('switching tabs updates panel id and aria-labelledby', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await user.click(screen.getByText('Resumen de gastos'))
+
+    const panel = screen.getByRole('tabpanel')
+    expect(panel).toHaveAttribute('id', 'panel-expenses')
+    expect(panel).toHaveAttribute('aria-labelledby', 'tab-expenses')
+  })
 })

--- a/src/features/reports/reports-page.tsx
+++ b/src/features/reports/reports-page.tsx
@@ -300,9 +300,11 @@ export function ReportsPage() {
           {tabs.map((tab) => (
             <button
               key={tab.key}
+              id={`tab-${tab.key}`}
               type="button"
               role="tab"
               aria-selected={activeTab === tab.key}
+              aria-controls={`panel-${tab.key}`}
               onClick={() => setActiveTab(tab.key)}
               className={`border-b-2 px-1 py-2 text-sm font-medium transition-colors ${
                 activeTab === tab.key
@@ -316,9 +318,16 @@ export function ReportsPage() {
         </nav>
       </div>
 
-      {activeTab === 'donations' && <DonationSummaryTab />}
-      {activeTab === 'expenses' && <ExpenseSummaryTab />}
-      {activeTab === 'donor-statement' && <DonorStatementTab />}
+      <div
+        role="tabpanel"
+        id={`panel-${activeTab}`}
+        aria-labelledby={`tab-${activeTab}`}
+        tabIndex={0}
+      >
+        {activeTab === 'donations' && <DonationSummaryTab />}
+        {activeTab === 'expenses' && <ExpenseSummaryTab />}
+        {activeTab === 'donor-statement' && <DonorStatementTab />}
+      </div>
     </div>
   )
 }

--- a/src/layouts/sidebar.test.tsx
+++ b/src/layouts/sidebar.test.tsx
@@ -77,3 +77,21 @@ describe('Sidebar role-based visibility', () => {
     ])
   })
 })
+
+describe('Sidebar landmark labels', () => {
+  it('aside has aria-label for main navigation', () => {
+    setUser('admin', ['ADMIN'])
+    renderSidebar()
+
+    const aside = screen.getByRole('complementary')
+    expect(aside).toHaveAttribute('aria-label', 'Navegación principal')
+  })
+
+  it('nav has aria-label for main navigation', () => {
+    setUser('admin', ['ADMIN'])
+    renderSidebar()
+
+    const nav = screen.getByRole('navigation', { name: 'Navegación principal' })
+    expect(nav).toBeInTheDocument()
+  })
+})

--- a/src/layouts/sidebar.tsx
+++ b/src/layouts/sidebar.tsx
@@ -83,8 +83,11 @@ export function Sidebar({ collapsed, onToggle }: SidebarProps) {
   const { t } = useTranslation()
   const { user } = useAuth()
 
+  const navLabel = t('sidebar.mainNavigation')
+
   return (
     <aside
+      aria-label={navLabel}
       className={cn(
         'bg-card flex h-screen flex-col border-r transition-[width] duration-200',
         collapsed ? 'w-16' : 'w-56'
@@ -102,7 +105,7 @@ export function Sidebar({ collapsed, onToggle }: SidebarProps) {
         )}
       </div>
 
-      <nav className="flex-1 space-y-1 p-2">
+      <nav aria-label={navLabel} className="flex-1 space-y-1 p-2">
         {navItems.map((item) => {
           if (item.visible && !item.visible(user)) return null
 

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -11,15 +11,15 @@
     "users": "Usuarios"
   },
   "auth": {
-    "login": "Iniciar sesi\u00f3n",
-    "logout": "Cerrar sesi\u00f3n",
+    "login": "Iniciar sesión",
+    "logout": "Cerrar sesión",
     "username": "Usuario",
-    "password": "Contrase\u00f1a",
+    "password": "Contraseña",
     "submit": "Ingresar",
     "submitting": "Ingresando...",
-    "changePassword": "Cambiar contrase\u00f1a",
-    "errorInvalidCredentials": "Usuario o contrase\u00f1a incorrectos",
-    "errorConnection": "Error de conexi\u00f3n. Intente nuevamente."
+    "changePassword": "Cambiar contraseña",
+    "errorInvalidCredentials": "Usuario o contraseña incorrectos",
+    "errorConnection": "Error de conexión. Intente nuevamente."
   },
   "dashboard": {
     "welcome": "Bienvenido, {{username}}",
@@ -27,34 +27,34 @@
     "totalIncome": "Ingresos totales",
     "totalExpenses": "Gastos totales",
     "netBalance": "Balance neto",
-    "newDonation": "Nueva donaci\u00f3n",
+    "newDonation": "Nueva donación",
     "newExpense": "Nuevo gasto",
     "donationsByType": "Donaciones por tipo",
-    "expensesByCategory": "Gastos por categor\u00eda",
+    "expensesByCategory": "Gastos por categoría",
     "selectRange": "Seleccione un rango de fechas",
     "errorLoading": "Error al cargar los datos del panel",
-    "noData": "Sin datos para el per\u00edodo seleccionado",
+    "noData": "Sin datos para el período seleccionado",
     "viewDonors": "Ver donantes",
-    "userManagement": "Gesti\u00f3n de usuarios",
+    "userManagement": "Gestión de usuarios",
     "totalUsers": "Usuarios registrados",
     "manageUsers": "Administrar usuarios",
     "financialOverview": "Resumen financiero"
   },
   "donations": {
     "title": "Donaciones",
-    "new": "Nueva donaci\u00f3n",
-    "edit": "Editar donaci\u00f3n",
+    "new": "Nueva donación",
+    "edit": "Editar donación",
     "amount": "Monto",
     "date": "Fecha",
     "type": "Tipo",
     "incomeMethod": "Método de ingreso",
-    "paymentMethod": "M\u00e9todo de pago",
+    "paymentMethod": "Método de pago",
     "donor": "Donante",
     "donorOptional": "Donante (opcional)",
     "notes": "Notas",
     "notesOptional": "Notas (opcional)",
-    "noDonor": "An\u00f3nimo",
-    "noNotes": "\u2014",
+    "noDonor": "Anónimo",
+    "noNotes": "—",
     "types": {
       "TITHE": "Diezmo",
       "OFFERING": "Ofrenda",
@@ -69,16 +69,16 @@
     "confirmSave": "Confirmar y guardar",
     "confirmEdit": "Confirmar cambios",
     "confirmEditDescription": "Se actualizarán los datos de esta donación.",
-    "successCreated": "Donaci\u00f3n creada exitosamente",
-    "successUpdated": "Donaci\u00f3n actualizada exitosamente",
-    "errorSaving": "Error al guardar la donaci\u00f3n",
+    "successCreated": "Donación creada exitosamente",
+    "successUpdated": "Donación actualizada exitosamente",
+    "errorSaving": "Error al guardar la donación",
     "errorLoading": "Error al cargar las donaciones",
     "empty": "No hay donaciones registradas",
-    "page": "P\u00e1gina {{page}} de {{total}}",
+    "page": "Página {{page}} de {{total}}",
     "previous": "Anterior",
     "next": "Siguiente",
     "selectType": "Seleccione tipo",
-    "selectPayment": "Seleccione m\u00e9todo",
+    "selectPayment": "Seleccione método",
     "selectDonor": "Seleccione donante",
     "editLabel": "Editar donación del {{date}}"
   },
@@ -207,8 +207,9 @@
     "errorCurrentPassword": "La contraseña actual es incorrecta"
   },
   "sidebar": {
-    "collapse": "Colapsar men\u00fa",
-    "expand": "Expandir men\u00fa"
+    "collapse": "Colapsar menú",
+    "expand": "Expandir menú",
+    "mainNavigation": "Navegación principal"
   },
   "common": {
     "loading": "Cargando...",
@@ -222,7 +223,7 @@
     "back": "Volver",
     "search": "Buscar",
     "actions": "Acciones",
-    "yes": "S\u00ed",
+    "yes": "Sí",
     "no": "No"
   }
 }


### PR DESCRIPTION
## Summary

- Sidebar `<aside>` and `<nav>` now carry `aria-label` from `sidebar.mainNavigation` so screen reader landmark navigation can identify the main nav region (WCAG 2.4.1).
- Reports tabs complete the ARIA tabs pattern: each tab button gets `id` + `aria-controls`, and the active panel is wrapped in `<div role="tabpanel" id aria-labelledby tabIndex={0}>` so keyboard users can Tab into panel content.
- Adds Spanish translation `sidebar.mainNavigation` ("Navegación principal").

## Related

- Closes #22 
- PRD: `docs/PRD-accessibility.md`
- Plan: `docs/plans/accessibility.md`

## Test plan

- [x] `npm run test` — 209 tests pass (5 new a11y tests across `sidebar.test.tsx` + `reports-page.test.tsx`)
- [x] `npm run check` — Biome clean
- [ ] Manual: VoiceOver landmark rotor lists sidebar as "Navegación principal"
- [ ] Manual: keyboard Tab from a Reports tab button enters the panel content
