### PR TITLE
feat(ux): SelectTrigger full width + remove Card from Change Password

### DIFF
--- a/src/features/donations/donation-form.tsx
+++ b/src/features/donations/donation-form.tsx
@@ -114,6 +114,7 @@ export function DonationForm({
               >
                 <SelectTrigger
                   id="donationType"
+                  className="w-full"
                   aria-invalid={!!errors.donationType}
                   aria-describedby={
                     errors.donationType ? 'donationType-error' : undefined
@@ -158,6 +159,7 @@ export function DonationForm({
               >
                 <SelectTrigger
                   id="paymentMethod"
+                  className="w-full"
                   aria-invalid={!!errors.paymentMethod}
                   aria-describedby={
                     errors.paymentMethod ? 'paymentMethod-error' : undefined
@@ -201,7 +203,7 @@ export function DonationForm({
               }
               onValueChange={(v) => field.onChange(v ? Number(v) : null)}
             >
-              <SelectTrigger>
+              <SelectTrigger className="w-full">
                 <SelectValue placeholder={t('donations.selectDonor')} />
               </SelectTrigger>
               <SelectContent>

--- a/src/features/expenses/expense-form.tsx
+++ b/src/features/expenses/expense-form.tsx
@@ -113,6 +113,7 @@ export function ExpenseForm({
               >
                 <SelectTrigger
                   id="category"
+                  className="w-full"
                   aria-invalid={!!errors.category}
                   aria-describedby={
                     errors.category ? 'category-error' : undefined
@@ -155,6 +156,7 @@ export function ExpenseForm({
               >
                 <SelectTrigger
                   id="paymentMethod"
+                  className="w-full"
                   aria-invalid={!!errors.paymentMethod}
                   aria-describedby={
                     errors.paymentMethod ? 'paymentMethod-error' : undefined

--- a/src/features/settings/change-password-page.tsx
+++ b/src/features/settings/change-password-page.tsx
@@ -5,7 +5,6 @@ import { useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import {
@@ -57,105 +56,96 @@ export function ChangePasswordPage() {
     <div className="space-y-6">
       <h1 className="text-2xl font-bold">{t('settings.changePassword')}</h1>
 
-      <Card className="max-w-md">
-        <CardHeader>
-          <CardTitle>{t('settings.changePassword')}</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
-            {success && (
-              <Alert>
-                <AlertDescription>
-                  {t('settings.successChanged')}
-                </AlertDescription>
-              </Alert>
-            )}
+      <form onSubmit={handleSubmit(onSubmit)} className="max-w-md space-y-4">
+        {success && (
+          <Alert>
+            <AlertDescription>{t('settings.successChanged')}</AlertDescription>
+          </Alert>
+        )}
 
-            {apiError && (
-              <Alert variant="destructive">
-                <AlertDescription>{apiError}</AlertDescription>
-              </Alert>
-            )}
+        {apiError && (
+          <Alert variant="destructive">
+            <AlertDescription>{apiError}</AlertDescription>
+          </Alert>
+        )}
 
-            <div className="space-y-2">
-              <Label htmlFor="currentPassword">
-                {t('settings.currentPassword')}
-              </Label>
-              <Input
-                id="currentPassword"
-                type="password"
-                autoComplete="current-password"
-                aria-invalid={!!errors.currentPassword}
-                aria-describedby={
-                  errors.currentPassword ? 'currentPassword-error' : undefined
-                }
-                {...register('currentPassword')}
-              />
-              {errors.currentPassword && (
-                <p
-                  id="currentPassword-error"
-                  role="alert"
-                  className="text-sm text-destructive"
-                >
-                  {errors.currentPassword.message}
-                </p>
-              )}
-            </div>
+        <div className="space-y-2">
+          <Label htmlFor="currentPassword">
+            {t('settings.currentPassword')}
+          </Label>
+          <Input
+            id="currentPassword"
+            type="password"
+            autoComplete="current-password"
+            aria-invalid={!!errors.currentPassword}
+            aria-describedby={
+              errors.currentPassword ? 'currentPassword-error' : undefined
+            }
+            {...register('currentPassword')}
+          />
+          {errors.currentPassword && (
+            <p
+              id="currentPassword-error"
+              role="alert"
+              className="text-sm text-destructive"
+            >
+              {errors.currentPassword.message}
+            </p>
+          )}
+        </div>
 
-            <div className="space-y-2">
-              <Label htmlFor="newPassword">{t('settings.newPassword')}</Label>
-              <Input
-                id="newPassword"
-                type="password"
-                autoComplete="new-password"
-                aria-invalid={!!errors.newPassword}
-                aria-describedby={
-                  errors.newPassword ? 'newPassword-error' : undefined
-                }
-                {...register('newPassword')}
-              />
-              {errors.newPassword && (
-                <p
-                  id="newPassword-error"
-                  role="alert"
-                  className="text-sm text-destructive"
-                >
-                  {errors.newPassword.message}
-                </p>
-              )}
-            </div>
+        <div className="space-y-2">
+          <Label htmlFor="newPassword">{t('settings.newPassword')}</Label>
+          <Input
+            id="newPassword"
+            type="password"
+            autoComplete="new-password"
+            aria-invalid={!!errors.newPassword}
+            aria-describedby={
+              errors.newPassword ? 'newPassword-error' : undefined
+            }
+            {...register('newPassword')}
+          />
+          {errors.newPassword && (
+            <p
+              id="newPassword-error"
+              role="alert"
+              className="text-sm text-destructive"
+            >
+              {errors.newPassword.message}
+            </p>
+          )}
+        </div>
 
-            <div className="space-y-2">
-              <Label htmlFor="confirmPassword">
-                {t('settings.confirmPassword')}
-              </Label>
-              <Input
-                id="confirmPassword"
-                type="password"
-                autoComplete="new-password"
-                aria-invalid={!!errors.confirmPassword}
-                aria-describedby={
-                  errors.confirmPassword ? 'confirmPassword-error' : undefined
-                }
-                {...register('confirmPassword')}
-              />
-              {errors.confirmPassword && (
-                <p
-                  id="confirmPassword-error"
-                  role="alert"
-                  className="text-sm text-destructive"
-                >
-                  {errors.confirmPassword.message}
-                </p>
-              )}
-            </div>
+        <div className="space-y-2">
+          <Label htmlFor="confirmPassword">
+            {t('settings.confirmPassword')}
+          </Label>
+          <Input
+            id="confirmPassword"
+            type="password"
+            autoComplete="new-password"
+            aria-invalid={!!errors.confirmPassword}
+            aria-describedby={
+              errors.confirmPassword ? 'confirmPassword-error' : undefined
+            }
+            {...register('confirmPassword')}
+          />
+          {errors.confirmPassword && (
+            <p
+              id="confirmPassword-error"
+              role="alert"
+              className="text-sm text-destructive"
+            >
+              {errors.confirmPassword.message}
+            </p>
+          )}
+        </div>
 
-            <Button type="submit" disabled={isSubmitting}>
-              {isSubmitting ? t('common.loading') : t('common.save')}
-            </Button>
-          </form>
-        </CardContent>
-      </Card>
+        <Button type="submit" disabled={isSubmitting}>
+          {isSubmitting ? t('common.loading') : t('common.save')}
+        </Button>
+      </form>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- Add `className="w-full"` to all `SelectTrigger` instances in `donation-form.tsx` (3) and `expense-form.tsx` (2) so select fields match adjacent input widths in the two-column grid
- Remove `<Card>` / `<CardHeader>` / `<CardTitle>` wrapper from Change Password page — single `<h1>` heading, form rendered directly with `max-w-md`
- Drop unused `Card`, `CardContent`, `CardHeader`, `CardTitle` imports from change-password-page

## Related

- Closes #34  
- PRD: `docs/PRD-accessibility.md`
- Plan: `docs/plans/accessibility.md`

## Test plan

- [x] Donation form — Type and Payment Method selects fill full column width, aligned with Amount and Date inputs
- [x] Expense form — Category and Payment Method selects fill full column width
- [ ] Change Password page — single `<h1>` heading, no duplicate card title, form is functional (submit, error, success states work)
- [x] No visual regression on any other page using SelectTrigger
