### PR TITLE
feat(ux): Skeleton loading state and EmptyState component on list pages

### DIFF
--- a/src/components/empty-state.test.tsx
+++ b/src/components/empty-state.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { EmptyState } from './empty-state'
+
+describe('EmptyState', () => {
+  it('renders icon, message, and CTA when all props provided', () => {
+    const handleClick = vi.fn()
+    render(
+      <EmptyState
+        icon={<span data-testid="icon" />}
+        message="No items"
+        cta={{ label: 'Create', onClick: handleClick }}
+      />
+    )
+    expect(screen.getByTestId('icon')).toBeInTheDocument()
+    expect(screen.getByText('No items')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Create' })).toBeInTheDocument()
+  })
+
+  it('renders without CTA when prop is omitted', () => {
+    render(<EmptyState icon={<span />} message="No items" />)
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+
+  it('calls onClick when CTA button is clicked', async () => {
+    const handleClick = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <EmptyState
+        icon={<span />}
+        message="No items"
+        cta={{ label: 'Create', onClick: handleClick }}
+      />
+    )
+    await user.click(screen.getByRole('button', { name: 'Create' }))
+    expect(handleClick).toHaveBeenCalledOnce()
+  })
+})

--- a/src/components/empty-state.tsx
+++ b/src/components/empty-state.tsx
@@ -1,0 +1,18 @@
+import type { ReactNode } from 'react'
+import { Button } from '@/components/ui/button'
+
+interface EmptyStateProps {
+  icon: ReactNode
+  message: string
+  cta?: { label: string; onClick: () => void }
+}
+
+export function EmptyState({ icon, message, cta }: EmptyStateProps) {
+  return (
+    <div className="flex flex-col items-center gap-4 py-16 text-center">
+      <div className="text-muted-foreground opacity-50">{icon}</div>
+      <p className="text-muted-foreground">{message}</p>
+      {cta && <Button onClick={cta.onClick}>{cta.label}</Button>}
+    </div>
+  )
+}

--- a/src/components/skeleton.test.tsx
+++ b/src/components/skeleton.test.tsx
@@ -1,0 +1,10 @@
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { Skeleton } from './skeleton'
+
+describe('Skeleton', () => {
+  it('renders aria-hidden="true"', () => {
+    const { container } = render(<Skeleton />)
+    expect(container.firstChild).toHaveAttribute('aria-hidden', 'true')
+  })
+})

--- a/src/components/skeleton.tsx
+++ b/src/components/skeleton.tsx
@@ -1,0 +1,8 @@
+export function Skeleton() {
+  return (
+    <div
+      aria-hidden="true"
+      className="h-10 animate-pulse rounded-md bg-muted"
+    />
+  )
+}

--- a/src/features/donations/donations-page.tsx
+++ b/src/features/donations/donations-page.tsx
@@ -4,6 +4,8 @@ import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link, useNavigate } from 'react-router'
 import { DateRangePicker } from '@/components/date-range-picker'
+import { EmptyState } from '@/components/empty-state'
+import { Skeleton } from '@/components/skeleton'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
 import { Button, buttonVariants } from '@/components/ui/button'
@@ -95,15 +97,28 @@ export function DonationsPage() {
       )}
 
       {isLoading && (
-        <Alert>
-          <AlertDescription>{t('common.loading')}</AlertDescription>
-        </Alert>
+        <div
+          aria-busy="true"
+          aria-label={t('common.loading')}
+          className="space-y-2"
+        >
+          <Skeleton />
+          <Skeleton />
+          <Skeleton />
+          <Skeleton />
+          <Skeleton />
+        </div>
       )}
 
       {data && data.content.length === 0 && (
-        <p className="py-8 text-center text-muted-foreground">
-          {t('donations.empty')}
-        </p>
+        <EmptyState
+          icon={<Plus size={40} />}
+          message={t('donations.empty')}
+          cta={{
+            label: t('donations.new'),
+            onClick: () => navigate('/donations/new'),
+          }}
+        />
       )}
 
       {data && data.content.length > 0 && (

--- a/src/features/donors/donors-page.tsx
+++ b/src/features/donors/donors-page.tsx
@@ -2,6 +2,8 @@ import { Pencil, Plus } from 'lucide-react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link, useNavigate } from 'react-router'
+import { EmptyState } from '@/components/empty-state'
+import { Skeleton } from '@/components/skeleton'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
 import { Button, buttonVariants } from '@/components/ui/button'
@@ -62,15 +64,28 @@ export function DonorsPage() {
       )}
 
       {isLoading && (
-        <Alert>
-          <AlertDescription>{t('common.loading')}</AlertDescription>
-        </Alert>
+        <div
+          aria-busy="true"
+          aria-label={t('common.loading')}
+          className="space-y-2"
+        >
+          <Skeleton />
+          <Skeleton />
+          <Skeleton />
+          <Skeleton />
+          <Skeleton />
+        </div>
       )}
 
       {data && data.content.length === 0 && (
-        <p className="py-8 text-center text-muted-foreground">
-          {t('donors.empty')}
-        </p>
+        <EmptyState
+          icon={<Plus size={40} />}
+          message={t('donors.empty')}
+          cta={{
+            label: t('donors.new'),
+            onClick: () => navigate('/donors/new'),
+          }}
+        />
       )}
 
       {data && data.content.length > 0 && (

--- a/src/features/expenses/expenses-page.tsx
+++ b/src/features/expenses/expenses-page.tsx
@@ -4,6 +4,8 @@ import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link, useNavigate } from 'react-router'
 import { DateRangePicker } from '@/components/date-range-picker'
+import { EmptyState } from '@/components/empty-state'
+import { Skeleton } from '@/components/skeleton'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
 import { Button, buttonVariants } from '@/components/ui/button'
@@ -95,15 +97,28 @@ export function ExpensesPage() {
       )}
 
       {isLoading && (
-        <Alert>
-          <AlertDescription>{t('common.loading')}</AlertDescription>
-        </Alert>
+        <div
+          aria-busy="true"
+          aria-label={t('common.loading')}
+          className="space-y-2"
+        >
+          <Skeleton />
+          <Skeleton />
+          <Skeleton />
+          <Skeleton />
+          <Skeleton />
+        </div>
       )}
 
       {data && data.content.length === 0 && (
-        <p className="py-8 text-center text-muted-foreground">
-          {t('expenses.empty')}
-        </p>
+        <EmptyState
+          icon={<Plus size={40} />}
+          message={t('expenses.empty')}
+          cta={{
+            label: t('expenses.new'),
+            onClick: () => navigate('/expenses/new'),
+          }}
+        />
       )}
 
       {data && data.content.length > 0 && (

--- a/src/features/users/users-page.tsx
+++ b/src/features/users/users-page.tsx
@@ -2,6 +2,8 @@ import { Pencil, Plus } from 'lucide-react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link, useNavigate } from 'react-router'
+import { EmptyState } from '@/components/empty-state'
+import { Skeleton } from '@/components/skeleton'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
 import { Button, buttonVariants } from '@/components/ui/button'
@@ -66,15 +68,25 @@ export function UsersPage() {
       )}
 
       {isLoading && (
-        <Alert>
-          <AlertDescription>{t('common.loading')}</AlertDescription>
-        </Alert>
+        <div
+          aria-busy="true"
+          aria-label={t('common.loading')}
+          className="space-y-2"
+        >
+          <Skeleton />
+          <Skeleton />
+          <Skeleton />
+          <Skeleton />
+          <Skeleton />
+        </div>
       )}
 
       {data && data.content.length === 0 && (
-        <p className="py-8 text-center text-muted-foreground">
-          {t('users.empty')}
-        </p>
+        <EmptyState
+          icon={<Plus size={40} />}
+          message={t('users.empty')}
+          cta={{ label: t('users.new'), onClick: () => navigate('/users/new') }}
+        />
       )}
 
       {data && data.content.length > 0 && (


### PR DESCRIPTION
## Summary

- New `Skeleton` component (`animate-pulse`, `bg-muted`, `rounded-md`, `aria-hidden="true"`)
- New `EmptyState` component — accepts icon, message, and optional CTA `{ label, onClick }`
- All four list pages (donations, donors, expenses, users) wired: 5 skeleton rows with `aria-busy="true"` / `aria-label` container on loading, `EmptyState` with entity-specific CTA on empty
- Unit tests: 4 passing (Skeleton aria-hidden, EmptyState with/without CTA, CTA onClick called)

## Related

- Closes 
  - #35 
  - #36  

## Test plan

- [x] Donations, Donors, Expenses, Users list pages show 5 animated skeleton rows while loading (not a text alert)
- [x] Skeleton animation suppressed with `prefers-reduced-motion` enabled (browser DevTools)
- [x] Empty state shows icon + message + CTA button on each list page when no records exist
- [x] CTA button navigates to the correct create route for each entity
- [x] EmptyState renders without CTA when prop is omitted (verified via unit test)
- [x] All unit tests pass
