### PR TITLE
feat(ux): header page title (Phase 4)

### DIFF
--- a/src/layouts/header.test.tsx
+++ b/src/layouts/header.test.tsx
@@ -1,0 +1,40 @@
+import { screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { renderWithProviders } from '@/test/test-utils'
+import { Header } from './header'
+
+beforeEach(() => {
+  localStorage.setItem(
+    'auth_user',
+    JSON.stringify({ username: 'testuser', roles: ['ADMIN'] })
+  )
+})
+
+describe('Header', () => {
+  it('renders user dropdown trigger', () => {
+    renderWithProviders(<Header />)
+    expect(
+      screen.getByRole('button', { name: /testuser/i })
+    ).toBeInTheDocument()
+  })
+
+  it('shows page title for dashboard route', () => {
+    renderWithProviders(<Header />, { route: '/' })
+    expect(screen.getByText('Inicio')).toBeInTheDocument()
+  })
+
+  it('shows page title for donations route', () => {
+    renderWithProviders(<Header />, { route: '/donations' })
+    expect(screen.getByText('Donaciones')).toBeInTheDocument()
+  })
+
+  it('shows page title for nested edit route', () => {
+    renderWithProviders(<Header />, { route: '/donations/3/edit' })
+    expect(screen.getByText('Donaciones')).toBeInTheDocument()
+  })
+
+  it('shows page title for settings route', () => {
+    renderWithProviders(<Header />, { route: '/settings/password' })
+    expect(screen.getByText('Cambiar contraseña')).toBeInTheDocument()
+  })
+})

--- a/src/layouts/header.tsx
+++ b/src/layouts/header.tsx
@@ -10,11 +10,13 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { useAuth } from '@/features/auth/auth-context'
+import { usePageTitle } from './use-page-title'
 
 export function Header() {
   const { t } = useTranslation()
   const { user, logout } = useAuth()
   const navigate = useNavigate()
+  const pageTitle = usePageTitle()
 
   function handleLogout() {
     logout()
@@ -26,7 +28,8 @@ export function Header() {
   }
 
   return (
-    <header className="bg-card flex h-14 items-center justify-end border-b px-4">
+    <header className="bg-card flex h-14 items-center justify-between border-b px-4">
+      <span className="text-sm font-medium">{pageTitle}</span>
       <DropdownMenu>
         <DropdownMenuTrigger
           className={buttonVariants({

--- a/src/layouts/use-page-title.test.ts
+++ b/src/layouts/use-page-title.test.ts
@@ -1,0 +1,29 @@
+import { renderHook } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { createWrapper } from '@/test/test-utils'
+import { usePageTitle } from './use-page-title'
+
+describe('usePageTitle', () => {
+  it.each([
+    ['/', 'Inicio'],
+    ['/donations', 'Donaciones'],
+    ['/donations/new', 'Donaciones'],
+    ['/donations/3/edit', 'Donaciones'],
+    ['/donors', 'Donantes'],
+    ['/donors/new', 'Donantes'],
+    ['/donors/5/edit', 'Donantes'],
+    ['/expenses', 'Gastos'],
+    ['/expenses/new', 'Gastos'],
+    ['/expenses/7/edit', 'Gastos'],
+    ['/reports', 'Reportes'],
+    ['/users', 'Usuarios'],
+    ['/users/new', 'Usuarios'],
+    ['/users/2/edit', 'Usuarios'],
+    ['/settings/password', 'Cambiar contraseña'],
+  ])('route %s → %s', (route, expected) => {
+    const { result } = renderHook(() => usePageTitle(), {
+      wrapper: createWrapper({ route }),
+    })
+    expect(result.current).toBe(expected)
+  })
+})

--- a/src/layouts/use-page-title.ts
+++ b/src/layouts/use-page-title.ts
@@ -1,0 +1,23 @@
+import { useTranslation } from 'react-i18next'
+import { useLocation } from 'react-router'
+
+const ROUTE_TITLE_MAP = [
+  { prefix: '/donations', key: 'nav.donations' },
+  { prefix: '/donors', key: 'nav.donors' },
+  { prefix: '/expenses', key: 'nav.expenses' },
+  { prefix: '/reports', key: 'nav.reports' },
+  { prefix: '/users', key: 'nav.users' },
+  { prefix: '/settings', key: 'settings.changePassword' },
+  { prefix: '/', key: 'nav.dashboard' },
+]
+
+export function usePageTitle(): string {
+  const { pathname } = useLocation()
+  const { t } = useTranslation()
+
+  const match = ROUTE_TITLE_MAP.find(
+    ({ prefix }) => pathname === prefix || pathname.startsWith(prefix + '/')
+  )
+
+  return match ? t(match.key) : ''
+}


### PR DESCRIPTION
## Summary

- New `usePageTitle` hook maps route prefixes to i18n translation keys
- Header renders section name on left side; user dropdown stays on right
- Edit/create routes show parent section name (e.g. `/donations/3/edit` → Donaciones)

## Related

- Closes #38 

## Test plan

- [x] 15 route cases covered in `use-page-title.test.ts`
- [x] 5 header tests in `header.test.tsx` (dropdown + 4 title scenarios)
- [x] All 241 tests pass, Biome lint clean
