### PR TITLE
refactor(lib): extract formatCurrency and currentMonthRange to shared formatters module

### DIFF
--- a/src/features/dashboard/financial-overview.tsx
+++ b/src/features/dashboard/financial-overview.tsx
@@ -14,27 +14,15 @@ import {
   ChartTooltip,
   ChartTooltipContent,
 } from '@/components/ui/chart'
+import { currentMonthRange, formatCurrency } from '@/lib/formatters'
 import {
   useBalance,
   useDonationSummary,
   useExpenseSummary,
 } from './use-dashboard-data'
 
-function currentMonthRange() {
-  const from = dayjs().startOf('month').toDate()
-  const to = dayjs().endOf('month').toDate()
-  return { from, to }
-}
-
 function formatDate(d: Date) {
   return dayjs(d).format('YYYY-MM-DD')
-}
-
-function formatCurrency(amount: number) {
-  return new Intl.NumberFormat('es-ES', {
-    style: 'currency',
-    currency: 'EUR',
-  }).format(amount)
 }
 
 const donationChartConfig: ChartConfig = {
@@ -163,7 +151,7 @@ export function FinancialOverview() {
             {donationChartData.length > 0 ? (
               <ChartContainer
                 config={donationChartConfig}
-                className="mx-auto aspect-square max-h-[300px]"
+                className="mx-auto aspect-square max-h-75"
               >
                 <PieChart>
                   <ChartTooltip

--- a/src/features/donations/donations-page.tsx
+++ b/src/features/donations/donations-page.tsx
@@ -17,21 +17,8 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
+import { currentMonthRange, formatCurrency } from '@/lib/formatters'
 import { useDonations } from './use-donations'
-
-function currentMonthRange() {
-  return {
-    from: dayjs().startOf('month').toDate(),
-    to: dayjs().endOf('month').toDate(),
-  }
-}
-
-function formatCurrency(amount: number) {
-  return new Intl.NumberFormat('es-ES', {
-    style: 'currency',
-    currency: 'EUR',
-  }).format(amount)
-}
 
 export function DonationsPage() {
   const { t } = useTranslation()

--- a/src/features/expenses/expenses-page.tsx
+++ b/src/features/expenses/expenses-page.tsx
@@ -17,21 +17,8 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
+import { currentMonthRange, formatCurrency } from '@/lib/formatters'
 import { useExpenses } from './use-expenses'
-
-function currentMonthRange() {
-  return {
-    from: dayjs().startOf('month').toDate(),
-    to: dayjs().endOf('month').toDate(),
-  }
-}
-
-function formatCurrency(amount: number) {
-  return new Intl.NumberFormat('es-ES', {
-    style: 'currency',
-    currency: 'EUR',
-  }).format(amount)
-}
 
 export function ExpensesPage() {
   const { t } = useTranslation()

--- a/src/features/reports/reports-page.tsx
+++ b/src/features/reports/reports-page.tsx
@@ -13,6 +13,7 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import { useDonors } from '@/features/donations/use-donations'
+import { currentMonthRange, formatCurrency } from '@/lib/formatters'
 import {
   useDonationReport,
   useDonorStatement,
@@ -21,22 +22,8 @@ import {
 
 type Tab = 'donations' | 'expenses' | 'donor-statement'
 
-function currentMonthRange() {
-  return {
-    from: dayjs().startOf('month').toDate(),
-    to: dayjs().endOf('month').toDate(),
-  }
-}
-
 function formatDate(d: Date) {
   return dayjs(d).format('YYYY-MM-DD')
-}
-
-function formatCurrency(amount: number) {
-  return new Intl.NumberFormat('es-ES', {
-    style: 'currency',
-    currency: 'EUR',
-  }).format(amount)
 }
 
 function DonationSummaryTab() {

--- a/src/lib/formatters.test.ts
+++ b/src/lib/formatters.test.ts
@@ -1,0 +1,45 @@
+import dayjs from 'dayjs'
+import { describe, expect, it } from 'vitest'
+import { currentMonthRange, formatCurrency } from './formatters'
+
+const fmt = (s: string) => s.replace(/\s/g, ' ')
+
+describe('formatCurrency', () => {
+  it('formats zero', () => {
+    expect(fmt(formatCurrency(0))).toBe('0,00 €')
+  })
+
+  it('formats positive integer', () => {
+    expect(fmt(formatCurrency(1000))).toBe('1000,00 €')
+  })
+
+  it('formats decimal with fractional digits', () => {
+    expect(fmt(formatCurrency(99.5))).toBe('99,50 €')
+  })
+
+  it('formats negative amount', () => {
+    expect(fmt(formatCurrency(-250))).toBe('-250,00 €')
+  })
+
+  it('formats large amount with grouping separators', () => {
+    expect(fmt(formatCurrency(1234567.89))).toBe('1.234.567,89 €')
+  })
+})
+
+describe('currentMonthRange', () => {
+  it('from equals start of current month', () => {
+    const { from } = currentMonthRange()
+    expect(from).toEqual(dayjs().startOf('month').toDate())
+  })
+
+  it('to equals end of current month', () => {
+    const { to } = currentMonthRange()
+    expect(to).toEqual(dayjs().endOf('month').toDate())
+  })
+
+  it('both values are Date instances', () => {
+    const { from, to } = currentMonthRange()
+    expect(from).toBeInstanceOf(Date)
+    expect(to).toBeInstanceOf(Date)
+  })
+})

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -1,0 +1,15 @@
+import dayjs from 'dayjs'
+
+export function formatCurrency(amount: number): string {
+  return new Intl.NumberFormat('es-ES', {
+    style: 'currency',
+    currency: 'EUR',
+  }).format(amount)
+}
+
+export function currentMonthRange(): { from: Date; to: Date } {
+  return {
+    from: dayjs().startOf('month').toDate(),
+    to: dayjs().endOf('month').toDate(),
+  }
+}


### PR DESCRIPTION
## Summary

- Extracted duplicate `formatCurrency` and `currentMonthRange` functions from 4 feature files into `src/lib/formatters.ts`
- Removed all 8 local definitions; replaced with a single import per file
- Added `src/lib/formatters.test.ts` with 8 unit tests covering zero, positive, decimal, negative, large amounts, and month range boundaries

## Changes

| File | Action |
|------|--------|
| `src/lib/formatters.ts` | New — exports `formatCurrency`, `currentMonthRange` |
| `src/lib/formatters.test.ts` | New — 8 unit tests |
| `src/features/donations/donations-page.tsx` | Remove local defs, import from `@/lib/formatters` |
| `src/features/expenses/expenses-page.tsx` | Remove local defs, import from `@/lib/formatters` |
| `src/features/dashboard/financial-overview.tsx` | Remove local defs, import from `@/lib/formatters` |
| `src/features/reports/reports-page.tsx` | Remove local defs, import from `@/lib/formatters` |

## Related

- Closes #49  

## Test plan

- [x] `npm run test` — 249 tests pass, no regressions
- [x] `npm run check` — Biome lint + import order clean
- [x] Verify currency amounts render identically on Dashboard, Donations, Expenses, and Reports pages
