### PR TITLE
fix(pre-commit): add typecheck command to pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
 lint-staged
+npm run typecheck

--- a/biome.json
+++ b/biome.json
@@ -79,6 +79,7 @@
             "noUnsafeOptionalChaining": "error",
             "noUnusedLabels": "error",
             "noUnusedPrivateClassMembers": "error",
+            "noUnusedImports": "error",
             "noUnusedVariables": "error",
             "useIsNan": "error",
             "useValidForDirection": "error",


### PR DESCRIPTION
## Summary

Found error in [CI](https://github.com/jorgetroya80/donations-frontend/actions/runs/25101593753/job/73552277750) in typecheck step, about unused import in some tests. The fix is add typescheck step in pre-commit hook and update Biome config.