### PR TITLE
fix(ci): docker-publish workflow_run trigger, skip logic, version extraction

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,8 +1,9 @@
 name: Docker Publish
 
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: ["Release Please"]
+    types: [completed]
 
 permissions:
   contents: read
@@ -11,21 +12,37 @@ jobs:
   docker:
     name: Build & Push Docker Image
     runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
 
-      - name: Extract version from tag
+      - name: Check release tag and extract version
         id: version
-        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+        run: |
+          git fetch --tags
+          TAG=$(git tag --points-at ${{ github.event.workflow_run.head_sha }})
+          if [ -z "$TAG" ]; then
+            echo "No release tag on this commit, skipping"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+          fi
 
       - uses: docker/setup-buildx-action@v3
+        if: steps.version.outputs.skip == 'false'
 
       - uses: docker/login-action@v3
+        if: steps.version.outputs.skip == 'false'
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - uses: docker/build-push-action@v6
+        if: steps.version.outputs.skip == 'false'
         with:
           context: .
           push: true


### PR DESCRIPTION
## Summary

- Replace `release: published` trigger with `workflow_run` on "Release Please" — fixes the root cause where `GITHUB_TOKEN`-created releases block downstream `release` events
- Add job-level guard (`conclusion == 'success'`) so docker job skips on release-please failure
- Add skip-and-version step: detects release tag on triggering commit SHA, exits cleanly when none found, extracts semver when found
- Fix version extraction — `GITHUB_REF_NAME` resolves to `main` in `workflow_run` context; now uses git tag instead

## Test plan

- [ ] Merge a release PR → confirm docker-publish triggers and image pushed with correct version + `latest` tags
- [ ] Merge a regular commit to `main` → confirm docker-publish triggers, skip-check finds no tag, exits cleanly with no image pushed
- [ ] Verify release-please failure → docker-publish job does not run


## Related

- Closes #58
- Closes #59
