### PR TITLE
fix(release): ensure GitHub pull request is skipped during release process

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,3 +18,4 @@ jobs:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
+          skip-github-pull-request: true


### PR DESCRIPTION
## Summary

- Move `skip-github-pull-request: true` from `.release-please-config.json` to the workflow action input — the config file option is not respected by release-please-action v5, it must be an explicit action input

## Root cause

PR #65 introduced `skip-github-pull-request: true` inside `.release-please-config.json` but the release-please-action v5 only reads this flag as an action input, not from the config file. This caused PR #66 to be created (old Release PR pattern) despite the config.

## Related issues

- Closes #63

## Test plan

- [x] Merge this PR — confirm release-please runs and creates a GitHub release + tag directly with no Release PR opened
- [x] Bot commit lands on main with bumped `package.json` and updated `CHANGELOG.md`
- [x] `docker-publish` triggers and pushes correctly tagged Docker image (tracked in #64)
