### PR TITLE
feat(docker): harden config and replace workflow_run publish trigger with workflow_dispatch

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,7 @@ dist
 .env*
 .dockerignore
 Dockerfile
+coverage/
+plans/
+.claude/
+*.log

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,9 +1,14 @@
 name: Docker Publish
 
 on:
-  workflow_run:
-    workflows: ['Release Please']
-    types: [completed]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Semantic version without v prefix (e.g. 1.2.3)'
+        required: true
+      sha:
+        description: 'Commit SHA to build from'
+        required: true
 
 permissions:
   contents: read
@@ -12,37 +17,19 @@ jobs:
   docker:
     name: Build & Push Docker Image
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success'
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
-          fetch-depth: 0
-
-      - name: Check release tag and extract version
-        id: version
-        run: |
-          git fetch --tags
-          TAG=$(git tag --points-at ${{ github.event.workflow_run.head_sha }})
-          if [ -z "$TAG" ]; then
-            echo "No release tag on this commit, skipping"
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-            echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
-          fi
+          ref: ${{ inputs.sha }}
 
       - uses: docker/setup-buildx-action@v4
-        if: steps.version.outputs.skip == 'false'
 
       - uses: docker/login-action@v4
-        if: steps.version.outputs.skip == 'false'
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - uses: docker/build-push-action@v7
-        if: steps.version.outputs.skip == 'false'
         with:
           context: .
           push: true
@@ -50,5 +37,5 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           tags: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/donations-frontend:${{ steps.version.outputs.version }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/donations-frontend:${{ inputs.version }}
             ${{ secrets.DOCKERHUB_USERNAME }}/donations-frontend:latest

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: write
 
 jobs:
   release-please:
@@ -14,3 +15,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v5
+        id: release
+
+      - name: Dispatch docker publish
+        if: steps.release.outputs.releases_created == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'docker-publish.yml',
+              ref: 'main',
+              inputs: {
+                version: '${{ steps.release.outputs.tag_name }}'.replace(/^v/, ''),
+                sha: context.sha
+              }
+            })

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,23 @@
 services:
   frontend:
-    build: .
+    build:
+      context: .
+      args:
+        VITE_API_URL: ${VITE_API_URL:-}
     ports:
       - "80:80"
     depends_on:
-      - api
+      api:
+        condition: service_healthy
     restart: unless-stopped
     networks:
       - app
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost/"]
+      interval: 30s
+      timeout: 3s
+      start_period: 5s
+      retries: 3
 
   api:
     image: jorgetroya/donations-api:latest
@@ -16,6 +26,12 @@ services:
     restart: unless-stopped
     networks:
       - app
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8080/health"]
+      interval: 10s
+      timeout: 5s
+      start_period: 10s
+      retries: 3
 
 networks:
   app:

--- a/docs/plans/docker-hardening.md
+++ b/docs/plans/docker-hardening.md
@@ -1,0 +1,97 @@
+# Plan: Docker Config Hardening + Precise Publish Trigger
+
+> Source: docker-expert review + docker-publish trigger improvement
+
+## Architectural decisions
+
+- **Trigger**: Replace `workflow_run` + tag-check skip logic with `workflow_dispatch` dispatched from `release-please.yml` only when `releases_created == 'true'` — eliminates wasted job runs on non-release pushes to main
+- **Version source**: `release-please-action` step output `tag_name` (e.g. `v0.2.2`) → strip `v` prefix for Docker tag
+- **SHA source**: `context.sha` from release-please workflow run (the merge commit that release-please tags)
+- **Serving**: nginx:1.27-alpine unchanged — master runs as root (port 80), workers drop to nginx user; accepted per existing PRD decision
+- **Environment config**: VITE_ vars baked at build time via Docker ARG; docker-compose passes via `args`
+
+---
+
+## Phase 1: Precise publish trigger via workflow_dispatch
+
+**Goal**: docker-publish only fires when release-please actually creates a release — no skip logic, no wasted runs.
+
+### What to build
+
+**`release-please.yml`** gains:
+- `actions: write` permission (needed to dispatch workflows)
+- An `id: release` on the `googleapis/release-please-action@v5` step to capture outputs
+- A conditional dispatch step: `if: steps.release.outputs.releases_created == 'true'` — calls `workflow_dispatch` on `docker-publish.yml` with `version` (tag without `v`) and `sha` (context.sha) inputs
+
+**`docker-publish.yml`** becomes:
+- Trigger: `workflow_dispatch` with inputs `version` (string, required) and `sha` (string, required)
+- Checkout uses `ref: ${{ inputs.sha }}`
+- Tags use `inputs.version`
+- Remove all `workflow_run` trigger, job-level `if`, skip-check step, and `skip` guards
+- Keep: buildx setup, login, build-push with GHA cache, `platforms: linux/amd64`
+
+### Acceptance criteria
+
+- [ ] Push a non-release commit to main (`chore:`) — `docker-publish` workflow does **not** appear in Actions run list
+- [ ] Merge a release PR (`feat:` or `fix:`) — release-please workflow creates a GitHub release, then immediately dispatches `docker-publish`; Docker Hub shows new image tagged with correct version and `latest`
+- [ ] `docker-publish.yml` contains no `workflow_run` trigger, no `skip` output checks, no `git fetch --tags`
+- [ ] `release-please.yml` has `actions: write` permission and a conditional dispatch step
+
+---
+
+## Phase 2: Docker config hardening
+
+**Goal**: Close gaps found in docker-expert review — compose health checks, .dockerignore coverage, nginx security headers.
+
+### What to build
+
+**`.dockerignore`** — add missing entries:
+```
+coverage/
+plans/
+.claude/
+*.log
+```
+
+**`docker-compose.yml`** — three additions:
+1. `build.args: VITE_API_URL: ${VITE_API_URL:-}` on `frontend` service (build arg currently never passed)
+2. `healthcheck` on `frontend` service (wires Dockerfile HEALTHCHECK into Compose wait condition)
+3. `healthcheck` on `api` service + tighten `depends_on` to `condition: service_healthy`
+
+```yaml
+frontend:
+  build:
+    context: .
+    args:
+      VITE_API_URL: ${VITE_API_URL:-}
+  healthcheck:
+    test: ["CMD", "wget", "-qO-", "http://localhost/"]
+    interval: 30s
+    timeout: 3s
+    start_period: 5s
+    retries: 3
+
+api:
+  healthcheck:
+    test: ["CMD", "wget", "-qO-", "http://localhost:8080/health"]
+    interval: 10s
+    timeout: 5s
+    start_period: 10s
+    retries: 3
+```
+
+> Adjust api health endpoint if `/health` is not the correct path for `jorgetroya/donations-api`.
+
+**`nginx.conf`** — three additions:
+- `gzip_vary on;` after `gzip_min_length` line (fixes CDN/proxy cache for compressed responses)
+- `add_header X-XSS-Protection "1; mode=block" always;`
+- `add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'" always;`
+
+### Acceptance criteria
+
+- [ ] `docker compose up --build` with `VITE_API_URL=http://api:8080` — build arg flows through to Vite build (visible in compiled JS or `docker inspect` build history)
+- [ ] `docker compose ps` shows both services as `healthy` after start period
+- [ ] `depends_on: api: condition: service_healthy` means frontend container waits for api health before starting
+- [ ] `curl -I http://localhost` response includes `X-XSS-Protection` and `Content-Security-Policy` headers
+- [ ] `curl -I --compressed http://localhost/assets/<any>.js` response includes `Vary: Accept-Encoding` header
+- [ ] `docker build .` excludes `coverage/`, `plans/`, `.claude/` from build context (verify with `docker build --no-cache --progress=plain . 2>&1 | grep -E "coverage|plans|\.claude"` returns nothing)

--- a/nginx.conf
+++ b/nginx.conf
@@ -6,10 +6,13 @@ server {
     gzip on;
     gzip_types text/plain text/css application/javascript application/json image/svg+xml;
     gzip_min_length 1024;
+    gzip_vary on;
 
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'" always;
 
     location /api/ {
         proxy_pass http://api:8080/;


### PR DESCRIPTION
## Summary

- Replace `workflow_run` + tag-check skip logic in `docker-publish.yml` with `workflow_dispatch` dispatched from `release-please.yml` only when `releases_created == 'true'` — eliminates wasted job runs on non-release pushes to main
- Add `actions: write` permission and conditional dispatch step to `release-please.yml`
- Harden `.dockerignore`, `docker-compose.yml`, and `nginx.conf` based on docker-expert review

## Test plan

- [ ] Push a `chore:` commit to main — `docker-publish` workflow does **not** appear in Actions run list
- [ ] Merge a release PR (`feat:` or `fix:`) — release-please dispatches `docker-publish`; Docker Hub shows new image tagged with correct version and `latest`
- [ ] `docker compose up --build` — both services show `healthy` status
- [ ] `curl -I http://localhost` — response includes `Content-Security-Policy` and `X-XSS-Protection` headers
- [ ] `curl -I --compressed http://localhost/assets/<any>.js` — response includes `Vary: Accept-Encoding`

Closes #73

