### PR TITLE
feat: single-command local full-stack environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,33 @@ App runs at http://localhost:3000
 | `npm run check`         | Biome lint + format     |
 | `npm run typecheck`     | TypeScript type check   |
 
-## Docker
+## Running Locally (Full Stack)
+
+**Prerequisites:** Docker
+
+Start both API and frontend with a single command:
+
+```bash
+docker compose up --build
+```
+
+App runs at http://localhost:8080
+
+To stop:
+
+```bash
+docker compose down
+```
+
+To rebuild after frontend changes:
+
+```bash
+docker compose up --build
+```
+
+The API image is always pulled fresh from Docker Hub on each `up`. No environment variables required.
+
+## Docker (frontend only)
 
 ```bash
 docker build -t donations-frontend .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       args:
         VITE_API_URL: ${VITE_API_URL:-}
     ports:
-      - "80:80"
+      - "8080:80"
     depends_on:
       api:
         condition: service_healthy
@@ -21,13 +21,14 @@ services:
 
   api:
     image: jorgetroya/donations-api:latest
+    pull_policy: always
     expose:
       - "8080"
     restart: unless-stopped
     networks:
       - app
     healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:8080/health"]
+      test: ["CMD", "wget", "-qO-", "http://localhost:8080/actuator/health"]
       interval: 10s
       timeout: 5s
       start_period: 10s

--- a/docs/plans/local-fullstack-env.md
+++ b/docs/plans/local-fullstack-env.md
@@ -1,0 +1,46 @@
+# Plan: Local Full-Stack Environment
+
+> Source PRD: https://github.com/jorgetroya80/donations-frontend/issues/76
+
+## Architectural decisions
+
+- **Service topology**: Two services — `frontend` (local production build via nginx) + `api` (published Docker image)
+- **API image**: `jorgetroya/donations-api:latest`, always pulled fresh via `pull_policy: always`
+- **Port**: Host `8080` → container `80` (nginx). No root required.
+- **API proxy**: nginx inside frontend container proxies `/api/` to `api:8080` over internal Docker network
+- **Network**: Isolated `app` bridge network. API port not exposed to host.
+- **Health check**: API uses `/actuator/health` (Spring Boot Actuator)
+- **Dependency**: Frontend waits for API `service_healthy` before starting
+- **No env vars**: API requires none currently; `.env` support can be added later
+
+---
+
+## Phase 1: Single-command full-stack setup
+
+**User stories**: 1, 2, 3, 4, 6, 7, 8, 9, 10, 11, 12
+
+### What to build
+
+Update `docker-compose.yml` so `docker compose up --build` starts both services end-to-end:
+
+- Frontend exposed on host port `8080`, served as a production nginx build from local source
+- API pulled fresh from published image on every `up`, health-checked via `/actuator/health`
+- Frontend depends on API being healthy before it starts
+- Both services on isolated bridge network; API not exposed to host
+
+Add a "Running Locally (Full Stack)" section to `README.md` covering:
+
+- Prerequisites (Docker)
+- Single command to start
+- URL to access the app
+- How to stop and rebuild
+
+### Acceptance criteria
+
+- [ ] `docker compose up --build` starts both services with a single command
+- [ ] App is accessible at `http://localhost:8080`
+- [ ] `docker compose ps` shows both services as healthy
+- [ ] Frontend starts only after API reports healthy
+- [ ] API requests from the frontend return 200 (verify via browser network tab)
+- [ ] `docker compose up` (without `--build`) pulls latest API image automatically
+- [ ] README includes prerequisites, start command, access URL, stop/rebuild instructions


### PR DESCRIPTION
## Summary

- Update `docker-compose.yml`: port `8080:80`, `pull_policy: always` on API image, healthcheck uses `/actuator/health`
- Add "Running Locally (Full Stack)" section to `README.md` with prerequisites, single command, stop/rebuild instructions

## Test plan

- [ ] `docker compose up --build` starts both services
- [ ] App accessible at `http://localhost:8080`
- [ ] `docker compose ps` shows both services healthy
- [ ] API requests return 200 in browser network tab

Closes #76
