### PR TITLE
feat(docker): add postgres and wire full local prod stack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+POSTGRES_DB=donations
+POSTGRES_USER=donations
+POSTGRES_PASSWORD=donations

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/README.md
+++ b/README.md
@@ -55,10 +55,14 @@ The API image is always pulled fresh from Docker Hub on each `up`. No environmen
 
 ## Docker (frontend only)
 
+Requires the API already running on port 8081.
+
 ```bash
 docker build -t donations-frontend .
-docker run -p 8080:80 donations-frontend
+docker run --name donations-frontend --rm -p 8080:80 --add-host=api:host-gateway donations-frontend
 ```
+
+`--add-host=api:host-gateway` maps the `api` hostname inside the container to your host machine, so nginx can proxy `/api/` to the running API.
 
 ## Architecture
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,14 @@ services:
     pull_policy: always
     expose:
       - '8081'
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/${POSTGRES_DB}
+      SPRING_DATASOURCE_USERNAME: ${POSTGRES_USER}
+      SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
+      SPRING_PROFILES_ACTIVE: prod
+    depends_on:
+      postgres:
+        condition: service_healthy
     restart: unless-stopped
     networks:
       - app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       args:
         VITE_API_URL: ${VITE_API_URL:-}
     ports:
-      - "8080:80"
+      - '8080:80'
     depends_on:
       api:
         condition: service_healthy
@@ -13,27 +13,49 @@ services:
     networks:
       - app
     healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost/"]
+      test: ['CMD', 'wget', '-qO-', 'http://localhost/']
       interval: 30s
       timeout: 3s
       start_period: 5s
       retries: 3
 
   api:
-    image: jorgetroya/donations-api:latest
+    image: jorgetroya/donations-api:main
     pull_policy: always
     expose:
-      - "8080"
+      - '8081'
     restart: unless-stopped
     networks:
       - app
     healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:8080/actuator/health"]
+      test: ['CMD', 'wget', '-qO-', 'http://localhost:8081/actuator/health']
       interval: 10s
       timeout: 5s
       start_period: 10s
       retries: 3
 
+  postgres:
+    image: postgres:18.3-bookworm
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    ports:
+      - '5432:5432'
+    volumes:
+      - postgres-data-prod:/var/lib/postgresql/data
+    restart: unless-stopped
+    networks:
+      - app
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}']
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
 networks:
   app:
     driver: bridge
+
+volumes:
+  postgres-data-prod:

--- a/docs/PRD-local-prod-stack.md
+++ b/docs/PRD-local-prod-stack.md
@@ -1,0 +1,89 @@
+# PRD: Local Prod Full-Stack Stack with Postgres
+
+## Problem Statement
+
+Developers cannot run the complete donations stack locally using production Docker images. The current `docker-compose.yml` includes the frontend and API services but omits the Postgres database, so the API container fails to start. There is no mechanism to supply database credentials safely, and the API runs with the `dev` Spring profile instead of `prod`, causing behavioral differences between local runs and production.
+
+## Solution
+
+Extend `docker-compose.yml` to include a Postgres service wired to the API container via a shared Docker network. Load all credentials from a gitignored `.env` file. Set the API to run with `SPRING_PROFILES_ACTIVE=prod`. Persist Postgres data across restarts using a named Docker volume. Expose Postgres on port 5432 so developers can inspect data with local tooling. Provide a committed `.env.example` template so new contributors know what variables are required.
+
+## User Stories
+
+1. As a developer, I want to run `docker compose up` and have the full stack (frontend, API, Postgres) start automatically, so that I can test end-to-end flows without manual setup.
+2. As a developer, I want the API to use the `prod` Spring profile locally, so that my local environment behaves like production and I can catch environment-specific bugs early.
+3. As a developer, I want database credentials loaded from a `.env` file, so that secrets are never committed to the repository.
+4. As a new contributor, I want a `.env.example` file committed to the repo, so that I know exactly which environment variables are required to run the stack.
+5. As a developer, I want Postgres data to persist across `docker compose down` / `docker compose up` cycles, so that I don't lose seed data or test records on every restart.
+6. As a developer, I want Postgres accessible on host port 5432, so that I can inspect and query the database using tools like psql, DBeaver, or pgAdmin.
+7. As a developer, I want the API container to wait for Postgres to be healthy before starting, so that the API doesn't crash on startup due to a missing database connection.
+8. As a developer, I want the API container to use the pre-built Docker Hub image (`jorgetroya/donations-api:main`), so that I run the same artifact that CI/CD ships to production.
+9. As a developer, I want the frontend container to wait for the API to be healthy before starting, so that the UI doesn't load with a broken backend.
+10. As a developer, I want a single `docker compose up --build` command to rebuild the frontend and start all services, so that local iteration is fast and predictable.
+11. As a developer, I want to tear down the stack without losing Postgres data using `docker compose down`, so that I can stop services temporarily and resume later.
+12. As a developer, I want to fully reset the stack including the database using `docker compose down -v`, so that I can start from a clean state when needed.
+13. As a developer, I want nginx to continue proxying `/api/` requests to the API container, so that there are no CORS issues and the local setup mirrors production routing.
+14. As a developer, I want the Postgres volume name to include a `-prod` suffix, so that it is clearly distinct from any future dev or test volumes.
+15. As a developer, I want all services to `restart: unless-stopped`, so that containers recover automatically if they crash during a long local session.
+
+## Implementation Decisions
+
+### docker-compose.yml
+- Add `postgres` service using `postgres:18.3-bookworm` image, matching the version used in the API repo's own compose file.
+- Postgres environment variables (`POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`) sourced from `.env` via Docker Compose variable substitution.
+- Postgres ports: `5432:5432` (exposed to host for tooling access).
+- Postgres named volume: `postgres-data-prod` mounted at `/var/lib/postgresql/data`.
+- Postgres healthcheck: `pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}`, interval 5s, timeout 5s, 5 retries.
+- `api` service retains `image: jorgetroya/donations-api:main` and `pull_policy: always`.
+- `api` service gains environment variables: `SPRING_DATASOURCE_URL` (pointing to `postgres` service via Docker DNS), `SPRING_DATASOURCE_USERNAME`, `SPRING_DATASOURCE_PASSWORD`, `SPRING_PROFILES_ACTIVE: prod`.
+- `api` service gains `depends_on: postgres: condition: service_healthy`.
+- `api` service keeps `expose: ['8081']` (not `ports`) so the API is only reachable via the nginx proxy.
+- `frontend` service unchanged except dependency chain now flows: postgres → api → frontend.
+- Add top-level `volumes:` block declaring `postgres-data-prod`.
+- All services remain on the `app` bridge network.
+
+### .env file (gitignored)
+- Variables: `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`.
+- File is gitignored so credentials are never committed.
+- Default values for local use: all three set to `donations`.
+
+### .env.example (committed)
+- Committed template with the same variables as `.env` and their default local values.
+- Documents required variables for new contributors.
+
+### .gitignore
+- Add `.env` entry. Currently only `.env.local` and `.env.*.local` variants are ignored; plain `.env` is not.
+
+### nginx.conf
+- No changes required. Already proxies `/api/` to `api:8081` and sets security headers.
+
+### Dockerfile
+- No changes required. `VITE_API_URL` build arg defaults to empty, which is correct — all API calls go through the nginx proxy at `/api/`.
+
+## Testing Decisions
+
+No automated tests for Docker/compose infrastructure. Manual verification:
+
+1. `docker compose up --build` → all three services reach `healthy` state (`docker compose ps`).
+2. `curl http://localhost:8080/api/actuator/health` → `{"status":"UP"}` (API alive via nginx proxy).
+3. `open http://localhost:8080` → frontend loads and can communicate with the API.
+4. `psql -h localhost -U donations -d donations` → connects to Postgres from host.
+5. `docker compose down && docker compose up` → Postgres data from previous run persists.
+6. `docker compose down -v` → named volume removed, clean slate on next `docker compose up`.
+7. Verify API container log shows Spring `prod` profile active on startup.
+
+## Out of Scope
+
+- Building the API from local source (this PRD uses the Docker Hub image only).
+- Non-local environments (staging, production deployment).
+- Database migrations or seed data automation.
+- SSL/TLS termination in the local stack.
+- Multi-architecture (arm64) builds.
+- Separate dev vs prod compose file variants.
+
+## Further Notes
+
+- The `api` service uses `expose` not `ports`, so the API is not directly reachable on the host. Use `curl http://localhost:8080/api/...` to reach it through nginx.
+- If the API's `prod` Spring profile requires additional environment variables (e.g. secrets, feature flags), add them to `.env` and reference them in the `api` service `environment` block.
+- To temporarily connect to the API directly (e.g. for debugging), add `ports: - "8081:8081"` to the `api` service. Remove when done.
+- `docker compose down` without `-v` leaves the `postgres-data-prod` volume intact. Always use `-v` for a full reset.

--- a/docs/plans/local-prod-stack.md
+++ b/docs/plans/local-prod-stack.md
@@ -1,0 +1,63 @@
+# Plan: Local Prod Full-Stack Stack with Postgres
+
+> Source PRD: docs/PRD-local-prod-stack.md
+
+## Architectural decisions
+
+- **Compose structure**: Single `docker-compose.yml` in the frontend repo — postgres, api, frontend on a shared `app` bridge network.
+- **API image**: Docker Hub only (`jorgetroya/donations-api:main`, `pull_policy: always`). No local source build.
+- **Spring profile**: `SPRING_PROFILES_ACTIVE: prod` injected via compose environment.
+- **Credentials**: Loaded from `.env` (gitignored). `.env.example` committed as template.
+- **Volume naming**: `postgres-data-prod` (explicit `-prod` suffix to distinguish from future dev/test volumes).
+- **API exposure**: `expose` not `ports` — API reachable only via nginx proxy at `/api/`. Port 8081 not mapped to host.
+- **Postgres exposure**: Port `5432:5432` mapped to host for local tooling (psql, DBeaver).
+- **Service ordering**: postgres → api (healthcheck gate) → frontend (healthcheck gate).
+
+---
+
+## Phase 1: Credentials + Postgres service
+
+**User stories**: 3, 4, 6, 7, 11, 12, 14, 15
+
+### What to build
+
+Establish secret management and bring up Postgres as a healthy, persistent service:
+
+- Add `.env` to `.gitignore` (currently only `.env.local` and `.env.*.local` are ignored).
+- Create `.env` (gitignored) with `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD` set to `donations`.
+- Create `.env.example` (committed) with the same variables as documentation for new contributors.
+- Add `postgres` service to `docker-compose.yml`: `postgres:18.3-bookworm`, env vars from `.env`, port `5432:5432`, named volume `postgres-data-prod`, healthcheck via `pg_isready`, `restart: unless-stopped`, `app` network.
+- Declare `postgres-data-prod` in the top-level `volumes:` block.
+
+### Acceptance criteria
+
+- [ ] `docker compose config` resolves all `${POSTGRES_*}` variables without error.
+- [ ] `docker compose up postgres` starts and reaches `healthy` state.
+- [ ] `psql -h localhost -U donations -d donations` connects from host.
+- [ ] `docker compose down && docker compose up postgres` — data from previous run persists in the named volume.
+- [ ] `docker compose down -v` removes `postgres-data-prod` volume; next `up` starts with empty DB.
+- [ ] `.env` is not tracked by git (`git status` shows it untracked/ignored).
+- [ ] `.env.example` is tracked by git.
+
+---
+
+## Phase 2: API prod wiring + full-stack verification
+
+**User stories**: 1, 2, 7, 8, 9, 10, 13, 15
+
+### What to build
+
+Wire the API container to Postgres with production configuration and verify the complete stack:
+
+- Add environment block to `api` service: `SPRING_DATASOURCE_URL` (pointing to `postgres` via Docker DNS), `SPRING_DATASOURCE_USERNAME`, `SPRING_DATASOURCE_PASSWORD` (all from `.env`), `SPRING_PROFILES_ACTIVE: prod`.
+- Add `depends_on: postgres: condition: service_healthy` to `api` service.
+- Run `docker compose up --build` and confirm all three services reach `healthy`.
+
+### Acceptance criteria
+
+- [ ] `docker compose up --build` → all three services (`postgres`, `api`, `frontend`) reach `healthy` (`docker compose ps`).
+- [ ] API log on startup shows Spring `prod` profile active.
+- [ ] `curl http://localhost:8080/api/actuator/health` → `{"status":"UP"}` (routed via nginx proxy).
+- [ ] Frontend loads at `http://localhost:8080` and can communicate with the API.
+- [ ] API container is not directly reachable on host port 8081 (only via nginx).
+- [ ] `docker compose down && docker compose up` → stack recovers, Postgres data intact.

--- a/nginx.conf
+++ b/nginx.conf
@@ -15,7 +15,7 @@ server {
     add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'" always;
 
     location /api/ {
-        proxy_pass http://api:8080/;
+        proxy_pass http://api:8081;
         proxy_http_version 1.1;
         proxy_set_header Connection "";
         proxy_set_header Host $host;


### PR DESCRIPTION
## Summary

- Add `postgres:18.3-bookworm` service to `docker-compose.yml` with named volume `postgres-data-prod`, healthcheck, and port 5432 exposed to host
- Wire `api` service to postgres via `SPRING_DATASOURCE_*` env vars + `SPRING_PROFILES_ACTIVE: prod`
- Add `.env` (gitignored) + `.env.example` (committed) for credential management
- Fix api image tag `latest` → `main` and port `8080` → `8081`
- Fix nginx `proxy_pass` port to match

Startup order enforced by healthcheck gates: postgres → api → frontend.

## Test plan

- [ ] `cp .env.example .env && docker compose up --build`
- [ ] `docker compose ps` → all three services `healthy`
- [ ] `curl http://localhost:8080/api/actuator/health` → `{"status":"UP"}`
- [ ] `open http://localhost:8080` → frontend loads and communicates with API
- [ ] API log shows Spring `prod` profile active
- [ ] `docker compose down && docker compose up` → postgres data persists
- [ ] `docker compose down -v` → clean slate on next `up`

## Relates

- Closes #82
- Closes #83