### PR TITLE
feat: add end-user setup scripts and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,37 @@
 
 Web app that helps small churches manage their finances — track tithes, offerings, and expenses, manage donor records, and view financial reports with charts and summaries. Supports role-based access so administrators, treasurers, and other staff see only what they need.
 
+## Running the App (End Users)
+
+**Prerequisite:** [Docker](https://www.docker.com/get-started)
+
+**First-time setup — run this once:**
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/jorgetroya80/donations-frontend/main/scripts/setup.sh | bash
+```
+
+> Verify the URL matches the [official repository](https://github.com/jorgetroya80/donations-frontend) before running.
+
+This downloads the app, creates your settings file, and pulls the Docker images into `~/donations/`.
+
+**Start the app:**
+
+```bash
+cd ~/donations && ./scripts/start.sh
+```
+
+Open **http://localhost:8080** in your browser.
+
+| Script | What it does |
+|---|---|
+| `./scripts/start.sh` | Start the app |
+| `./scripts/stop.sh` | Stop the app (data is kept) |
+| `./scripts/update.sh` | Update to the latest version |
+| `./scripts/reset.sh` | Wipe database and start fresh |
+
+---
+
 ## Prerequisites
 
 - Node.js >= 24

--- a/README.md
+++ b/README.md
@@ -31,27 +31,28 @@ App runs at http://localhost:3000
 
 **Prerequisites:** Docker
 
-Start both API and frontend with a single command:
+1. Copy environment file:
 
-```bash
-docker compose up --build
-```
+   ```bash
+   cp .env.example .env
+   ```
+
+   Defaults work out of the box — no edits needed for local development.
+
+2. Start API and frontend:
+
+   ```bash
+   docker compose up --build
+   ```
 
 App runs at http://localhost:8080
 
-To stop:
-
-```bash
-docker compose down
-```
-
-To rebuild after frontend changes:
-
-```bash
-docker compose up --build
-```
-
-The API image is always pulled fresh from Docker Hub on each `up`. No environment variables required.
+| Command | Effect |
+|---|---|
+| `docker compose up --build` | Start + rebuild frontend image |
+| `docker compose down` | Stop (data persists) |
+| `docker compose down -v` | Stop + wipe database |
+| `docker compose pull` | Pull latest API image |
 
 ## Docker (frontend only)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
 
   api:
     image: jorgetroya/donations-api:main
+    platform: linux/amd64
     pull_policy: always
     expose:
       - '8081'
@@ -51,7 +52,7 @@ services:
     ports:
       - '5432:5432'
     volumes:
-      - postgres-data-prod:/var/lib/postgresql/data
+      - postgres-data-prod:/var/lib/postgresql
     restart: unless-stopped
     networks:
       - app

--- a/docs/PRD-end-user-setup.md
+++ b/docs/PRD-end-user-setup.md
@@ -1,0 +1,109 @@
+# PRD: End-User Setup Scripts and README Update
+
+## Problem Statement
+
+Two groups of people need to run the donations app locally, but the README does not serve either well:
+
+1. **Frontend developers** are told "no environment variables required" — now incorrect after adding the Postgres service. They hit a broken setup with no guidance on the `.env` file.
+2. **End users** (admins, treasurers, and other non-technical staff) have no supported way to run the app at all. The README assumes Node.js knowledge and git familiarity that most church staff do not have.
+
+## Solution
+
+Fix the developer section of the README to reflect the new `.env` requirement, and add a new end-user section backed by five shell scripts. End users run a single `curl` command to bootstrap everything, then use named scripts (`start.sh`, `stop.sh`, `update.sh`, `reset.sh`) for day-to-day operation. The only prerequisite for end users is Docker.
+
+## User Stories
+
+1. As a frontend developer, I want the README to tell me to copy `.env.example` to `.env` before running the stack, so that I don't hit a broken setup with missing environment variables.
+2. As a frontend developer, I want the README to remove the incorrect "no environment variables required" line, so that I am not misled about what the stack needs.
+3. As a frontend developer, I want a clear table of `docker compose` commands in the README, so that I can stop, rebuild, update, and reset the stack without guessing.
+4. As a church admin, I want to run a single command in my terminal to set up the app for the first time, so that I don't need to understand git, Node.js, or Docker Compose configuration.
+5. As a church admin, I want the setup script to check that Docker is installed and give me a clear message if it isn't, so that I know exactly what to install before retrying.
+6. As a church admin, I want the setup script to create a dedicated folder on my machine for the app files, so that my home directory stays organized.
+7. As a church admin, I want the setup script to download all necessary configuration files automatically, so that I never have to manually locate or copy files from GitHub.
+8. As a church admin, I want the setup script to create my local settings file only if one doesn't exist yet, so that re-running setup never overwrites my existing configuration.
+9. As a church admin, I want the setup script to pre-download the Docker images so that starting the app for the first time is fast, so that I don't sit waiting for a download on first launch.
+10. As a church admin, I want the setup script to also download the other management scripts, so that I have everything I need after running setup once.
+11. As a church admin, I want to run `./scripts/start.sh` to start the app, so that I don't need to remember Docker Compose commands.
+12. As a church admin, I want `start.sh` to run the app in the background (detached), so that I can close the terminal window without stopping the app.
+13. As a church admin, I want `start.sh` to print the URL where the app is running, so that I know where to open my browser.
+14. As a church admin, I want to run `./scripts/stop.sh` to stop the app, so that I can shut it down without losing my data.
+15. As a church admin, I want `stop.sh` to confirm that data is preserved after stopping, so that I don't worry about losing records.
+16. As a church admin, I want to run `./scripts/update.sh` to get the latest version of the app, so that I benefit from bug fixes and new features without reinstalling everything.
+17. As a church admin, I want `update.sh` to restart the app automatically after updating, so that I don't need to manually start it again.
+18. As a church admin, I want to run `./scripts/reset.sh` to wipe the database and start fresh, so that I can recover from a corrupted state or start a new financial period cleanly.
+19. As a church admin, I want `reset.sh` to warn me and give me time to cancel before deleting data, so that I don't accidentally lose records.
+20. As a church admin, I want the README end-user section to be written in plain language without developer jargon, so that I can follow it without technical knowledge.
+21. As a church admin, I want the README to list all available scripts and what they do in a simple table, so that I can quickly find the command I need.
+
+## Implementation Decisions
+
+### README changes
+
+- Add "Running the App (End Users)" section placed before the developer "Getting Started" section — different audience, higher priority for most visitors.
+- Section contains: single `curl | bash` setup command, link to Docker install page as the only prerequisite, table of scripts and their plain-language descriptions.
+- Fix "Running Locally (Full Stack)" section: insert `cp .env.example .env` as step 1, remove the now-incorrect "no environment variables required" sentence, add a reference table of `docker compose` commands.
+
+### `scripts/setup.sh`
+
+- Verify Docker is installed; print an actionable error and exit if not.
+- Create `~/donations/` as the working directory for end-user files.
+- Download `docker-compose.yml` and `.env.example` from the raw GitHub URL into `~/donations/`.
+- Copy `.env.example` → `.env` only when `.env` does not already exist — never overwrite.
+- Download all four remaining scripts into `~/donations/scripts/` and mark them executable.
+- Run `docker compose pull` to pre-fetch images.
+- Print a success message with the next step (`./scripts/start.sh`).
+
+### `scripts/start.sh`
+
+- Run `docker compose up -d` (detached mode).
+- Print the app URL: `http://localhost:8080`.
+
+### `scripts/stop.sh`
+
+- Run `docker compose down`.
+- Print confirmation that data is preserved.
+
+### `scripts/update.sh`
+
+- Run `docker compose pull` to fetch latest images.
+- Run `docker compose up -d` to restart with new images.
+- Print confirmation.
+
+### `scripts/reset.sh`
+
+- Print a clear data-loss warning.
+- Sleep 5 seconds to give the user time to press `Ctrl+C`.
+- Run `docker compose down -v` to remove containers and the named volume.
+- Run `docker compose up -d` to start fresh.
+- Print the app URL.
+
+### Script delivery
+
+- All scripts committed to the `scripts/` folder in this repository.
+- `setup.sh` is the entry point delivered via `curl -fsSL <raw-url> | bash`.
+- `setup.sh` downloads the other scripts so the end user never needs to interact with the repo directly after setup.
+
+## Testing Decisions
+
+Shell scripts have no automated test suite in this codebase. Manual verification is the testing strategy:
+
+- Run `curl | bash` on a machine with Docker installed and confirm `~/donations/` is created with all expected files.
+- Run `setup.sh` a second time and confirm `.env` is not overwritten.
+- Run `setup.sh` without Docker installed and confirm the error message is clear and the script exits cleanly.
+- Run each script in sequence (`start`, `stop`, `update`, `reset`) and verify the described behavior.
+- Verify `reset.sh` cancellable by pressing `Ctrl+C` during the 5-second wait.
+
+## Out of Scope
+
+- Windows or macOS-native (non-Docker) installation paths.
+- GUI installer or packaged app (e.g. Electron).
+- Automated script testing (shell unit tests).
+- Multi-user or networked deployment (scripts target a single local machine).
+- Custom `.env` values beyond the defaults — scripts use defaults that work out of the box.
+- Uninstall script.
+
+## Further Notes
+
+- The `curl | bash` pattern has known security implications. Since this is an internal church tool from a known GitHub repository, the risk is acceptable. The README should note that users should verify the URL matches the official repository before running.
+- Scripts assume `docker-compose.yml` lives one level above the `scripts/` directory, i.e. `~/donations/docker-compose.yml` with scripts at `~/donations/scripts/`.
+- If the user already has port 8080 or 5432 in use, Docker Compose will fail with a port conflict. This is out of scope for the scripts but worth noting in the README troubleshooting section in a future iteration.

--- a/docs/plans/end-user-setup.md
+++ b/docs/plans/end-user-setup.md
@@ -1,0 +1,93 @@
+# Plan: End-User Setup Scripts and README Update
+
+> Source PRD: docs/PRD-end-user-setup.md
+
+## Architectural decisions
+
+- **Script location**: `scripts/` folder in repo root, committed and executable.
+- **End-user working dir**: `~/donations/` — setup.sh creates this and downloads all files there.
+- **Script delivery**: `setup.sh` is the curl entry point; it downloads the other 4 scripts into `~/donations/scripts/`.
+- **Docker mode**: all scripts use detached mode (`docker compose up -d`) so the app runs in background.
+- **No-overwrite rule**: setup.sh never overwrites an existing `.env` file.
+- **Raw GitHub URLs**: scripts download files from `raw.githubusercontent.com/jorgetroya80/donations-frontend/main/`.
+
+---
+
+## Phase 1: Fix developer README
+
+**User stories**: 1, 2, 3
+
+### What to build
+
+Update the existing "Running Locally (Full Stack)" section in `README.md`:
+- Add `cp .env.example .env` as step 1 before `docker compose up --build`
+- Note that defaults work out of the box — no edits needed
+- Remove the now-incorrect "The API image is always pulled fresh from Docker Hub on each `up`. No environment variables required." sentence
+- Add a reference table of `docker compose` commands (up --build, down, down -v, pull)
+
+### Acceptance criteria
+
+- [ ] README "Running Locally" section includes `cp .env.example .env` as the first step
+- [ ] The "no environment variables required" line is gone
+- [ ] A docker compose command table is present with at minimum: `up --build`, `down`, `down -v`, `pull`
+- [ ] `docker compose up --build` still works correctly after following the updated instructions
+
+---
+
+## Phase 2: Management scripts
+
+**User stories**: 11, 12, 13, 14, 15, 16, 17, 18, 19
+
+### What to build
+
+Create four scripts in `scripts/` — each does one operation and prints a plain-language confirmation:
+
+- `start.sh` — runs `docker compose up -d`, prints `http://localhost:8080`
+- `stop.sh` — runs `docker compose down`, confirms data is preserved
+- `update.sh` — runs `docker compose pull` then `docker compose up -d`, confirms update
+- `reset.sh` — prints data-loss warning, sleeps 5s for cancellation, runs `docker compose down -v` then `docker compose up -d`, prints app URL
+
+All scripts must be marked executable (`chmod +x`). Each script operates relative to the directory where `docker-compose.yml` lives (one level above `scripts/`).
+
+### Acceptance criteria
+
+- [ ] `./scripts/start.sh` starts all services in detached mode and prints `http://localhost:8080`
+- [ ] `./scripts/stop.sh` stops the stack and confirms data is preserved
+- [ ] `./scripts/update.sh` pulls latest images and restarts the stack
+- [ ] `./scripts/reset.sh` prints warning, waits 5s, wipes volume, restarts stack, prints app URL
+- [ ] `Ctrl+C` during `reset.sh` wait cancels the operation without data loss
+- [ ] All four scripts are executable (`ls -la scripts/` shows `x` bit set)
+
+---
+
+## Phase 3: Setup script + end-user README section
+
+**User stories**: 4, 5, 6, 7, 8, 9, 10, 20, 21
+
+### What to build
+
+Create `scripts/setup.sh` — the curl entry point for end users:
+- Check Docker is installed; print actionable error and exit if not
+- Create `~/donations/` directory
+- Download `docker-compose.yml` and `.env.example` from raw GitHub into `~/donations/`
+- Copy `.env.example` → `.env` only if `.env` does not already exist
+- Download all four management scripts into `~/donations/scripts/` and mark them executable
+- Run `docker compose pull` to pre-fetch images
+- Print success message and next step: `./scripts/start.sh`
+
+Add "Running the App (End Users)" section to `README.md`, placed before the developer "Getting Started" section:
+- Single `curl -fsSL ... | bash` command as the entry point
+- Docker as the only prerequisite (with install link)
+- Plain-language numbered steps
+- Table of scripts and their plain-language descriptions
+- Security note: verify URL matches official repository before running
+
+### Acceptance criteria
+
+- [ ] Running `curl -fsSL <raw-url>/scripts/setup.sh | bash` on a clean machine with Docker creates `~/donations/` with `docker-compose.yml`, `.env`, `.env.example`, and all four scripts
+- [ ] Running setup a second time does not overwrite an existing `.env`
+- [ ] Running setup without Docker installed exits with a clear, actionable error message
+- [ ] `docker compose pull` runs during setup and pre-fetches all images
+- [ ] README has a new "Running the App (End Users)" section before "Getting Started"
+- [ ] README section contains the `curl` command, script table, and security note
+- [ ] After setup, `./scripts/start.sh` brings the app up at `http://localhost:8080`

--- a/scripts/reset.sh
+++ b/scripts/reset.sh
@@ -3,15 +3,15 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-if command -v tput &>/dev/null && tput setaf 1 &>/dev/null; then
+if command -v tput &>/dev/null && tput setaf 1 &>/dev/null 2>&1; then
   RED="$(tput setaf 1)"
   RESET="$(tput sgr0)"
 else
-  RED='\033[0;31m'
-  RESET='\033[0m'
+  RED=$'\033[0;31m'
+  RESET=$'\033[0m'
 fi
 
-echo -e "${RED}WARNING: This will permanently delete all data.${RESET}"
+printf '%sWARNING: This will permanently delete all data.%s\n' "$RED" "$RESET"
 echo "Press Ctrl+C within 5 seconds to cancel..."
 sleep 5
 

--- a/scripts/reset.sh
+++ b/scripts/reset.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+if command -v tput &>/dev/null && tput setaf 1 &>/dev/null; then
+  RED="$(tput setaf 1)"
+  RESET="$(tput sgr0)"
+else
+  RED='\033[0;31m'
+  RESET='\033[0m'
+fi
+
+echo -e "${RED}WARNING: This will permanently delete all data.${RESET}"
+echo "Press Ctrl+C within 5 seconds to cancel..."
+sleep 5
+
+docker compose down -v
+docker compose up -d
+
+echo "Database reset. App is running at http://localhost:8080"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Check Docker is installed
+if ! command -v docker &>/dev/null; then
+  echo "Docker is not installed. Please install it from https://www.docker.com/get-started and try again."
+  exit 1
+fi
+
+INSTALL_DIR="$HOME/donations"
+
+# Create install directory
+mkdir -p "$INSTALL_DIR"
+mkdir -p "$INSTALL_DIR/scripts"
+
+BASE_URL="https://raw.githubusercontent.com/jorgetroya80/donations-frontend/main"
+
+# Download core files
+echo "Downloading configuration files..."
+curl -fsSL "$BASE_URL/docker-compose.yml" -o "$INSTALL_DIR/docker-compose.yml"
+curl -fsSL "$BASE_URL/.env.example" -o "$INSTALL_DIR/.env.example"
+
+# Copy .env only if it does not already exist
+if [ ! -f "$INSTALL_DIR/.env" ]; then
+  cp "$INSTALL_DIR/.env.example" "$INSTALL_DIR/.env"
+else
+  echo "Existing .env file kept — not overwritten."
+fi
+
+# Download management scripts
+echo "Downloading management scripts..."
+for script in start.sh stop.sh update.sh reset.sh; do
+  curl -fsSL "$BASE_URL/scripts/$script" -o "$INSTALL_DIR/scripts/$script"
+  chmod +x "$INSTALL_DIR/scripts/$script"
+done
+
+# Pull Docker images
+echo "Pulling Docker images..."
+cd "$INSTALL_DIR" && docker compose pull
+
+echo ""
+echo "Setup complete! To start the app, run:"
+echo "  cd ~/donations && ./scripts/start.sh"
+echo ""
+echo "Then open http://localhost:8080 in your browser."

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+docker compose up -d
+
+echo "App is running at http://localhost:8080"

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+docker compose down
+
+echo "App stopped. Your data is preserved."

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+docker compose pull
+docker compose up -d
+
+echo "Updated to the latest version. App is running at http://localhost:8080"


### PR DESCRIPTION
## Summary

- Add `scripts/setup.sh` — `curl | bash` entry point for non-technical users (admins). Downloads `docker-compose.yml`, `.env.example`, and all management scripts to `~/donations/`. Guards existing `.env` on re-run. Pre-pulls Docker images.
- Add `scripts/start.sh`, `stop.sh`, `update.sh`, `reset.sh` — plain-language wrappers around `docker compose` for day-to-day app management
- Fix `reset.sh` ANSI color portability: `echo -e` + `\033` unreliable on macOS zsh → `printf` + `$'\033'` quoting
- Fix README "Running Locally (Full Stack)": add `cp .env.example .env` step, remove incorrect "no env vars" line, add command table
- Add README "Running the App (End Users)" section with `curl | bash` setup command, script table, and security note

## Test plan

- [ ] `curl -fsSL https://raw.githubusercontent.com/jorgetroya80/donations-frontend/main/scripts/setup.sh | bash` creates `~/donations/` with all files and pre-pulls images
- [ ] Re-running setup does not overwrite existing `.env`
- [ ] Running setup without Docker exits with clear error message
- [ ] `./scripts/start.sh` → app at http://localhost:8080
- [ ] `./scripts/stop.sh` → stack stops, data preserved
- [ ] `./scripts/update.sh` → pulls latest images and restarts
- [ ] `./scripts/reset.sh` → 5s warning, wipes DB, restarts
- [ ] `Ctrl+C` during `reset.sh` wait cancels without data loss
- [ ] README end-user section renders correctly on GitHub

## Relates

- Closes #86