### PR TITLE
fix(docker): add frontend image tag so end-user scripts can pull without Dockerfile

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   frontend:
+    image: jorgetroya/donations-frontend:latest
     build:
       context: .
       args:


### PR DESCRIPTION
## Summary

End users running `./scripts/start.sh` from `~/donations/` (where `setup.sh` installs the app) got:

```
failed to solve: failed to read dockerfile: open Dockerfile: no such file or directory
```

The frontend service had only `build: context: .` — no `image:` tag. Without source code in `~/donations/`, Docker Compose tried to build and failed.

Adding `image: jorgetroya/donations-frontend:latest` alongside `build:` fixes this:
- `docker compose up -d` → pulls pre-built image from Docker Hub (end users ✓)
- `docker compose up --build` → builds from local source (devs ✓)
- `docker compose pull` → now pulls frontend image too ✓

## Test plan

- [ ] `cd ~/donations && ./scripts/start.sh` → all services start, no Dockerfile error
- [ ] `cd ~/donations && docker compose pull` → pulls both `jorgetroya/donations-api:main` and `jorgetroya/donations-frontend:latest`
- [ ] `docker compose up --build` from repo root → still builds frontend from local source

Closes #89