### PR TITLE
fix(docker): add ARM64/multi-arch support

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           context: .
           push: true
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
           tags: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,9 +1,79 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code when working with code in this repository.
+Behavioral guidelines to reduce common LLM coding mistakes. Merge with project-specific instructions as needed.
+
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+---
+
+**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.
+
+---
 
 ## Commands
 
+- `npm run build` — Build application
 - `npm run dev` / `npm start` — Start dev server (port 3000)
 - `npm run check` — Biome lint + format with auto-fix (`src/**/*.{ts,tsx}`)
 - `npm run lint` — Biome lint with auto-fix (`src/**/*.{ts,tsx}`)
@@ -20,9 +90,3 @@ React 19 + TypeScript + Vite 8 SPA for a donations frontend.
 - **Tailwind CSS v4** via `@tailwindcss/vite` plugin
 - **Linting**: Biome (format + lint + import organizing)
 - **lint-staged**: Biome runs on staged files for formatting (all files) and linting (ts/tsx)
-
-## Code Style
-
-- Single quotes, no semicolons, trailing commas (ES5), spaces (2)
-- `const` over `let`, no `var`, no `any`
-- Target: ES2023, module resolution: bundler

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   frontend:
     image: jorgetroya/donations-frontend:latest
+    platform: linux/amd64
     build:
       context: .
       args:

--- a/docs/plans/arm64-multi-arch-docker.md
+++ b/docs/plans/arm64-multi-arch-docker.md
@@ -1,0 +1,42 @@
+# Plan: ARM64 / Multi-Arch Docker Support
+
+> Source PRD: Fix `setup.sh` failure on Apple Silicon Macs and ARM Windows due to missing `linux/arm64` manifest
+
+## Architectural decisions
+
+- **Image registry**: Docker Hub — `jorgetroya/donations-frontend`
+- **CI build tool**: `docker/build-push-action` with `docker/setup-buildx-action` (already in workflow)
+- **Compose workaround pattern**: `platform: linux/amd64` — already used by `api` service
+
+---
+
+## Phase 1: Compose platform workaround
+
+**User stories**: ARM64 user runs `setup.sh` and gets `no matching manifest for linux/arm64/v8` error
+
+### What to build
+
+Add `platform: linux/amd64` to the `frontend` service in `docker-compose.yml`. This mirrors the existing pattern on the `api` service and instructs Docker to pull the amd64 image on ARM hosts (runs via Rosetta/QEMU emulation). No rebuild or new release needed — the fix takes effect as soon as the updated `docker-compose.yml` is on the main branch, because `setup.sh` downloads it fresh from GitHub each run.
+
+### Acceptance criteria
+
+- [ ] `frontend` service in `docker-compose.yml` has `platform: linux/amd64`
+- [ ] Running `setup.sh` on Apple Silicon Mac completes without manifest error
+- [ ] App loads at `http://localhost:8080` after setup on ARM host
+
+---
+
+## Phase 2: Multi-arch CI build
+
+**User stories**: ARM64 users get native (non-emulated) performance; Docker Hub manifest includes both amd64 and arm64
+
+### What to build
+
+Add `linux/arm64` to the `platforms` field in `.github/workflows/docker-publish.yml`. `docker/setup-buildx-action` is already present so buildx multi-arch is ready. Next release will push a manifest list containing both `linux/amd64` and `linux/arm64` images. After this ships, the `platform: linux/amd64` override on the `frontend` service in `docker-compose.yml` can be removed (arm64 image will be natively available).
+
+### Acceptance criteria
+
+- [ ] `platforms` in `docker-publish.yml` is `linux/amd64,linux/arm64`
+- [ ] After next release, Docker Hub shows both amd64 and arm64 manifests for `jorgetroya/donations-frontend`
+- [ ] ARM64 host pulls and runs native arm64 image (no emulation layer)
+- [ ] `platform: linux/amd64` override removed from `frontend` service in `docker-compose.yml`


### PR DESCRIPTION
## Summary

- Adds `platform: linux/amd64` to `frontend` service in `docker-compose.yml` so ARM64 hosts (Apple Silicon, ARM Windows) can pull the existing amd64 image via Rosetta/QEMU emulation
- Adds `linux/arm64` to CI `docker-publish.yml` platforms so future releases ship a native arm64 image

## Test plan

- [ ] Run `setup.sh` on Apple Silicon Mac — completes without `no matching manifest for linux/arm64/v8` error
- [ ] App loads at `http://localhost:8080` after setup on ARM host
- [ ] After next release, verify Docker Hub manifest list includes both `linux/amd64` and `linux/arm64` for `jorgetroya/donations-frontend`

## Related

- Closes #92
