### PR TITLE
feat(deps): remove unused dependencies date-fns and @rolldown/plugin-babel

### DIFF
--- a/docs/PRD-remove-unused-deps.md
+++ b/docs/PRD-remove-unused-deps.md
@@ -1,0 +1,48 @@
+## Problem Statement
+
+Two packages are listed as direct dependencies in `package.json` but are never imported in source code or referenced in build configuration. These dead dependencies add noise to the dependency tree, increase install time, and create false audit surface for security scanning.
+
+- `date-fns` (dependency) — installed alongside `react-day-picker` under the assumption that v9 required it as a peer dependency (v8 did). `react-day-picker` v9 dropped that requirement. All date formatting in the project uses `dayjs`.
+- `@rolldown/plugin-babel` (devDependency) — installed experimentally to explore Rolldown build mode. Never wired into `vite.config.ts`. All Babel transforms are handled by `@vitejs/plugin-react`.
+
+## Solution
+
+Remove both unused packages from `package.json` and regenerate the lockfile. Verify that build, tests, and lint all pass after removal.
+
+## User Stories
+
+1. As a developer, I want the dependency list to only contain packages that are actually used, so that I can quickly understand what the project depends on.
+2. As a developer, I want to reduce unnecessary packages, so that `pnpm install` is faster in CI and local environments.
+3. As a developer, I want fewer packages in the dependency tree, so that security audits (`pnpm audit`) report on a smaller, more relevant surface.
+4. As a developer, I want to remove `date-fns` from dependencies, so that there is no confusion about which date library the project uses (`dayjs`).
+5. As a developer, I want to remove `@rolldown/plugin-babel` from devDependencies, so that the build config accurately reflects what Vite plugins are in use.
+6. As a future contributor, I want a clean `package.json`, so that I don't accidentally import a package that appears available but serves no purpose.
+
+## Implementation Decisions
+
+- Remove `date-fns` from `dependencies` in `package.json` using `pnpm remove date-fns`.
+- Remove `@rolldown/plugin-babel` from `devDependencies` in `package.json` using `pnpm remove -D @rolldown/plugin-babel`.
+- `pnpm-lock.yaml` will be regenerated automatically.
+- No source file changes required — neither package is imported anywhere.
+- No config file changes required — `vite.config.ts` does not reference `@rolldown/plugin-babel`.
+- Date formatting continues to use `dayjs` exclusively.
+- Babel transforms continue to be handled by `@vitejs/plugin-react` with `babel-plugin-react-compiler`.
+
+## Testing Decisions
+
+- Good tests verify external behavior, not implementation details.
+- No new tests needed — this change removes dead packages, not behavior.
+- Verification: `pnpm run build` must pass (no missing module errors), `pnpm run test` must pass (no broken imports in test setup), `pnpm run check` must pass (Biome lint + format clean).
+
+## Out of Scope
+
+- Adding security scanning or `pnpm audit` to CI (separate initiative).
+- Evaluating whether `dayjs` should be replaced by `date-fns` or vice versa.
+- Removing `prettier` from dependencies (it is a devDependency-class tool but its placement is a separate discussion).
+- Evaluating Rolldown build mode for the project.
+
+## Further Notes
+
+- `date-fns` was added in commit `2b7ebaa` (Apr 21 2026, "Phase 3 — dashboard home with balance cards and charts") but never imported in the source files introduced by that commit.
+- `react-day-picker` v9's `peerDependencies` only lists `react` — confirmed `date-fns` is not required.
+- `@rolldown/plugin-babel` is only relevant if explicitly opting into Rolldown build mode via `builder: 'rolldown'` in `vite.config.ts`, which this project does not do.

--- a/docs/plans/remove-unused-deps.md
+++ b/docs/plans/remove-unused-deps.md
@@ -1,0 +1,29 @@
+# Plan: Remove Unused Dependencies
+
+> Source PRD: docs/PRD-remove-unused-deps.md
+
+## Architectural decisions
+
+- **No routes changed** — frontend routing unaffected.
+- **No schema changes** — data models unaffected.
+- **Date library**: `dayjs` remains the sole date utility. `date-fns` is not a replacement candidate.
+- **Babel pipeline**: `@vitejs/plugin-react` owns all Babel transforms. `@rolldown/plugin-babel` is not part of the build.
+
+---
+
+## Phase 1: Remove both unused packages
+
+**User stories**: 1, 2, 3, 4, 5, 6
+
+### What to build
+
+Remove `date-fns` from `dependencies` and `@rolldown/plugin-babel` from `devDependencies`. Neither package is imported in source code or referenced in build config, so no source changes are required. The lockfile regenerates automatically.
+
+### Acceptance criteria
+
+- [ ] `date-fns` absent from `package.json` dependencies
+- [ ] `@rolldown/plugin-babel` absent from `package.json` devDependencies
+- [ ] `pnpm run build` passes with no missing module errors
+- [ ] `pnpm run test` passes with no broken imports
+- [ ] `pnpm run check` passes (Biome lint + format clean)
+- [ ] `pnpm-lock.yaml` updated and committed

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "@tanstack/react-query": "5.99.2",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
-    "date-fns": "4.1.0",
     "dayjs": "1.11.20",
     "i18next": "26.0.6",
     "ky": "2.0.1",
@@ -49,7 +48,6 @@
   "devDependencies": {
     "@babel/core": "7.29.0",
     "@biomejs/biome": "2.4.12",
-    "@rolldown/plugin-babel": "0.2.3",
     "@tailwindcss/vite": "4.2.2",
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "16.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,9 +26,6 @@ importers:
       clsx:
         specifier: 2.1.1
         version: 2.1.1
-      date-fns:
-        specifier: 4.1.0
-        version: 4.1.0
       dayjs:
         specifier: 1.11.20
         version: 1.11.20
@@ -84,9 +81,6 @@ importers:
       '@biomejs/biome':
         specifier: 2.4.12
         version: 2.4.12
-      '@rolldown/plugin-babel':
-        specifier: 0.2.3
-        version: 0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.0-rc.16)(vite@8.0.9(@types/node@24.12.2)(jiti@2.7.0)(yaml@2.9.0))
       '@tailwindcss/vite':
         specifier: 4.2.2
         version: 4.2.2(vite@8.0.9(@types/node@24.12.2)(jiti@2.7.0)(yaml@2.9.0))
@@ -113,7 +107,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: 6.0.1
-        version: 6.0.1(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.0-rc.16)(vite@8.0.9(@types/node@24.12.2)(jiti@2.7.0)(yaml@2.9.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.0.9(@types/node@24.12.2)(jiti@2.7.0)(yaml@2.9.0))
+        version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.9(@types/node@24.12.2)(jiti@2.7.0)(yaml@2.9.0))
       '@vitest/coverage-v8':
         specifier: 4.1.5
         version: 4.1.5(vitest@4.1.5)
@@ -589,23 +583,6 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
-
-  '@rolldown/plugin-babel@0.2.3':
-    resolution: {integrity: sha512-+zEk16yGlz1F9STiRr6uG9hmIXb6nprjLczV/htGptYuLoCuxb+itZ03RKCEeOhBpDDd1NU7qF6x1VLMUp62bw==}
-    engines: {node: '>=22.12.0 || ^24.0.0'}
-    peerDependencies:
-      '@babel/core': ^7.29.0 || ^8.0.0-rc.1
-      '@babel/plugin-transform-runtime': ^7.29.0 || ^8.0.0-rc.1
-      '@babel/runtime': ^7.27.0 || ^8.0.0-rc.1
-      rolldown: ^1.0.0-rc.5
-      vite: ^8.0.0
-    peerDependenciesMeta:
-      '@babel/plugin-transform-runtime':
-        optional: true
-      '@babel/runtime':
-        optional: true
-      vite:
-        optional: true
 
   '@rolldown/pluginutils@1.0.0-rc.16':
     resolution: {integrity: sha512-45+YtqxLYKDWQouLKCrpIZhke+nXxhsw+qAHVzHDVwttyBlHNBVs2K25rDXrZzhpTp9w1FlAlvweV1H++fdZoA==}
@@ -2368,15 +2345,6 @@ snapshots:
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.16':
     optional: true
 
-  '@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.0-rc.16)(vite@8.0.9(@types/node@24.12.2)(jiti@2.7.0)(yaml@2.9.0))':
-    dependencies:
-      '@babel/core': 7.29.0
-      picomatch: 4.0.4
-      rolldown: 1.0.0-rc.16
-    optionalDependencies:
-      '@babel/runtime': 7.29.2
-      vite: 8.0.9(@types/node@24.12.2)(jiti@2.7.0)(yaml@2.9.0)
-
   '@rolldown/pluginutils@1.0.0-rc.16': {}
 
   '@rolldown/pluginutils@1.0.0-rc.7': {}
@@ -2577,12 +2545,11 @@ snapshots:
 
   '@types/use-sync-external-store@0.0.6': {}
 
-  '@vitejs/plugin-react@6.0.1(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.0-rc.16)(vite@8.0.9(@types/node@24.12.2)(jiti@2.7.0)(yaml@2.9.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.0.9(@types/node@24.12.2)(jiti@2.7.0)(yaml@2.9.0))':
+  '@vitejs/plugin-react@6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.9(@types/node@24.12.2)(jiti@2.7.0)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
       vite: 8.0.9(@types/node@24.12.2)(jiti@2.7.0)(yaml@2.9.0)
     optionalDependencies:
-      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.0-rc.16)(vite@8.0.9(@types/node@24.12.2)(jiti@2.7.0)(yaml@2.9.0))
       babel-plugin-react-compiler: 1.0.0
 
   '@vitest/coverage-v8@4.1.5(vitest@4.1.5)':


### PR DESCRIPTION
## Summary

- Remove `date-fns` from dependencies — never imported; `react-day-picker` v9 dropped it as a peer dep, all date ops use `dayjs`
- Remove `@rolldown/plugin-babel` from devDependencies — installed experimentally, never wired into `vite.config.ts`; `@vitejs/plugin-react` owns the Babel pipeline

## Test plan

- [x] `pnpm run build` passes
- [x] `pnpm run test` passes (262 tests)
- [x] `pnpm run check` passes (Biome clean)