### PR TITLE
feat: password visibility toggle on Input component

### DIFF
--- a/docs/PRD-input-password-toggle.md
+++ b/docs/PRD-input-password-toggle.md
@@ -1,0 +1,61 @@
+# PRD: Password Visibility Toggle
+
+## Problem Statement
+
+Users filling in password fields (login, change password, user management) have no way to verify what they typed. A single mistyped character forces them to clear the field and retype, with no visual feedback. This is especially frustrating on mobile or when entering complex passwords.
+
+## Solution
+
+Add a show/hide toggle button inside every password input field. When the user clicks the eye icon, the field switches from masked to readable text. Clicking again masks it. The toggle is built into the shared `Input` component so it applies automatically to all password fields across the app without any changes at call sites.
+
+## User Stories
+
+1. As a user logging in, I want to reveal my password before submitting, so that I can confirm I typed it correctly.
+2. As a user changing my password, I want to toggle visibility on the current password field, so that I can verify I'm entering the right password.
+3. As a user changing my password, I want to toggle visibility on the new password field, so that I can confirm I'm typing what I intend.
+4. As a user changing my password, I want to toggle visibility on the confirm password field, so that I can check both fields match before submitting.
+5. As an admin creating a new user, I want to toggle the password field, so that I can verify the password I'm assigning.
+6. As an admin editing a user, I want to toggle the password field, so that I can confirm the new password before saving.
+7. As a screen reader user, I want the toggle button to have a descriptive label, so that I know what the button does before activating it.
+8. As a Spanish-speaking user, I want all UI labels to be in Spanish, so that the interface is consistent with the rest of the application.
+9. As a user, I want the toggle button to be visually inside the input field, so that the form layout does not shift when the toggle is present.
+10. As a user, I want the toggle button to not interfere with typing, so that my text is never obscured by the button.
+11. As a user with limited mobility, I want the toggle button to be keyboard-accessible, so that I can reveal my password without a mouse.
+
+## Implementation Decisions
+
+- The toggle is built into the shared `Input` component and activates automatically when `type="password"`. No call-site changes are required.
+- When `type` is not `"password"`, the component renders exactly as before — no behavioral change.
+- The input is wrapped in a `relative` container div only when `type="password"`. The toggle button is absolutely positioned on the right side. The input receives extra right padding to prevent text from overlapping the button.
+- The toggle uses `Eye` and `EyeOff` icons from `lucide-react`, the icon library already used in the project.
+- Two new Spanish translation keys are added under the `common` namespace: one for "show password" and one for "hide password".
+- The `Input` component uses the `useTranslation` hook to access these keys for the button's `aria-label`, which switches dynamically with the toggle state.
+- The toggle button has `type="button"` to prevent accidental form submission.
+
+## Testing Decisions
+
+A good test verifies external behavior: what the user sees and interacts with — not implementation details like internal state variable names or component structure.
+
+**Modules to test:** The `Input` component.
+
+**Test cases:**
+- When `type="password"`, an eye icon button is rendered.
+- When `type` is anything other than `"password"`, no toggle button is rendered.
+- Clicking the toggle changes the input's `type` attribute from `password` to `text`.
+- Clicking the toggle a second time changes the input's `type` attribute back to `password`.
+- The toggle button's `aria-label` reads "Mostrar contraseña" when password is hidden.
+- The toggle button's `aria-label` reads "Ocultar contraseña" when password is visible.
+
+**Prior art:** Check existing component tests in the project for patterns on rendering and user interaction with `@testing-library/react`.
+
+## Out of Scope
+
+- Per-field opt-out (all password fields get the toggle).
+- Auto-hide after a timeout.
+- Any changes to password validation logic.
+- Multi-language support beyond Spanish.
+
+## Further Notes
+
+- The `Input` component currently wraps `@base-ui/react/input`. The password branch wraps that primitive in a plain `div` — no new base-ui primitives introduced.
+- All three forms that use password inputs (login, change-password, user-form) benefit automatically.

--- a/docs/plans/input-password-toggle.md
+++ b/docs/plans/input-password-toggle.md
@@ -1,0 +1,52 @@
+# Plan: Password Visibility Toggle
+
+> Source PRD: docs/PRD-input-password-toggle.md — Issue #99
+
+## Architectural decisions
+
+- **Scope**: Change is contained to the shared `Input` component and the Spanish locale file. No route, schema, or API changes.
+- **Activation**: Toggle renders automatically when `type="password"`. Zero call-site changes.
+- **Icons**: `Eye` / `EyeOff` from `lucide-react` (already a project dependency).
+- **i18n**: Two new keys under `common` namespace in `src/locales/es.json`.
+- **Layout**: Wrapper `div` with `relative` positioning. Button absolutely positioned right. Input gets extra right padding to prevent text overlap.
+
+---
+
+## Phase 1: Toggle implementation
+
+**User stories**: 1, 2, 3, 4, 5, 6, 8, 9, 10, 11
+
+### What to build
+
+Add two Spanish translation keys (`common.showPassword`, `common.hidePassword`). Modify the `Input` component so that when `type="password"`, it renders a relative wrapper containing the input and an absolutely-positioned toggle button. Clicking the button switches the input between `password` and `text` types and swaps the icon. The button carries a dynamic Spanish `aria-label` that reflects current state. Non-password inputs are unaffected.
+
+### Acceptance criteria
+
+- [ ] Eye icon button appears on all password fields (login, change-password ×3, user-form)
+- [ ] Clicking the button reveals the typed password as plain text
+- [ ] Clicking again masks the password
+- [ ] Icon switches between Eye and EyeOff on each click
+- [ ] Form layout does not shift when toggle is present
+- [ ] Typed text is not obscured by the toggle button
+- [ ] Button is reachable and activatable via keyboard (Tab + Enter/Space)
+- [ ] `aria-label` reads "Mostrar contraseña" when masked, "Ocultar contraseña" when visible
+- [ ] Non-password inputs render exactly as before
+
+---
+
+## Phase 2: Unit tests
+
+**Testing decisions from PRD**
+
+### What to build
+
+Write unit tests for the `Input` component covering the password toggle behavior. Tests assert external behavior only — what the user sees and what attributes the DOM exposes — not internal state.
+
+### Acceptance criteria
+
+- [ ] Test: `type="password"` renders an eye toggle button
+- [ ] Test: `type="text"` (and other non-password types) renders no toggle button
+- [ ] Test: clicking toggle changes input `type` attribute from `password` to `text`
+- [ ] Test: clicking toggle a second time changes input `type` attribute back to `password`
+- [ ] Test: button `aria-label` is "Mostrar contraseña" when password is hidden
+- [ ] Test: button `aria-label` is "Ocultar contraseña" when password is visible

--- a/src/components/ui/input.test.tsx
+++ b/src/components/ui/input.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+
+import { Input } from './input'
+
+describe('Input', () => {
+  describe('type="password"', () => {
+    it('renders toggle button with aria-label "Mostrar contraseña"', () => {
+      render(<Input type="password" />)
+      expect(
+        screen.getByRole('button', { name: 'Mostrar contraseña' })
+      ).toBeInTheDocument()
+    })
+
+    it('clicking toggle reveals password and updates aria-label', async () => {
+      const user = userEvent.setup()
+      render(<Input type="password" placeholder="pw" />)
+      const input = screen.getByPlaceholderText('pw')
+
+      await user.click(
+        screen.getByRole('button', { name: 'Mostrar contraseña' })
+      )
+
+      expect(input).toHaveAttribute('type', 'text')
+      expect(
+        screen.getByRole('button', { name: 'Ocultar contraseña' })
+      ).toBeInTheDocument()
+    })
+
+    it('clicking toggle twice masks password again', async () => {
+      const user = userEvent.setup()
+      render(<Input type="password" placeholder="pw" />)
+      const input = screen.getByPlaceholderText('pw')
+
+      await user.click(
+        screen.getByRole('button', { name: 'Mostrar contraseña' })
+      )
+      await user.click(
+        screen.getByRole('button', { name: 'Ocultar contraseña' })
+      )
+
+      expect(input).toHaveAttribute('type', 'password')
+      expect(
+        screen.getByRole('button', { name: 'Mostrar contraseña' })
+      ).toBeInTheDocument()
+    })
+  })
+
+  describe('non-password type', () => {
+    it('renders no toggle button', () => {
+      render(<Input type="text" />)
+      expect(screen.queryByRole('button')).not.toBeInTheDocument()
+    })
+  })
+})

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,17 +1,45 @@
 import { Input as InputPrimitive } from '@base-ui/react/input'
+import { Eye, EyeOff } from 'lucide-react'
 import * as React from 'react'
+import { useTranslation } from 'react-i18next'
 
 import { cn } from '@/lib/utils'
 
+const baseClass =
+  'border-input file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 disabled:bg-input/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 h-8 w-full min-w-0 rounded-lg border bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-3 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:ring-3 md:text-sm'
+
 function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
+  const { t } = useTranslation()
+  const [showPassword, setShowPassword] = React.useState(false)
+
+  if (type === 'password') {
+    return (
+      <div className="relative">
+        <InputPrimitive
+          type={showPassword ? 'text' : 'password'}
+          data-slot="input"
+          className={cn(baseClass, 'pr-8', className)}
+          {...props}
+        />
+        <button
+          type="button"
+          aria-label={
+            showPassword ? t('common.hidePassword') : t('common.showPassword')
+          }
+          onClick={() => setShowPassword((v) => !v)}
+          className="absolute inset-y-0 right-2 flex items-center text-muted-foreground hover:text-foreground"
+        >
+          {showPassword ? <EyeOff size={16} /> : <Eye size={16} />}
+        </button>
+      </div>
+    )
+  }
+
   return (
     <InputPrimitive
       type={type}
       data-slot="input"
-      className={cn(
-        'border-input file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 disabled:bg-input/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 h-8 w-full min-w-0 rounded-lg border bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-3 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:ring-3 md:text-sm',
-        className
-      )}
+      className={cn(baseClass, className)}
       {...props}
     />
   )

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -224,7 +224,9 @@
     "search": "Buscar",
     "actions": "Acciones",
     "yes": "Sí",
-    "no": "No"
+    "no": "No",
+    "showPassword": "Mostrar contraseña",
+    "hidePassword": "Ocultar contraseña"
   },
   "theme": {
     "switchToLight": "Cambiar a modo claro",


### PR DESCRIPTION
Closes #99

## Summary

- Modified `Input` component to auto-render eye toggle when `type="password"` — zero call-site changes
- Added `common.showPassword` / `common.hidePassword` Spanish i18n keys
- Added unit tests covering render, click behavior, and aria-label state

## Relates
- Close #99 

## Test plan

- [x] Login page — eye icon appears on password field, toggle works
- [x] Change password page — all 3 fields have working toggles
- [x] User form — password field has working toggle
- [x] Keyboard: Tab to button, Enter/Space toggles visibility

