### PR TITLE
chore: update github-script action to v8 in release workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Dispatch docker publish
         if: steps.release.outputs.releases_created == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             await github.rest.actions.createWorkflowDispatch({


### PR DESCRIPTION
## Summary

Update actions/github-script to `v8` to update Node.js version support to 24.x