### PR TITLE
chore: add Dependabot for donations-api-client npm package

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    allow:
+      - dependency-name: "@jorgetroya80/donations-api-client"


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` scoped to `@jorgetroya80/donations-api-client` only
- Weekly schedule — Dependabot opens a PR whenever a new version is published to GitHub Packages
- Frontend pins exact version and merges the update deliberately

## Context

Part of the OpenAPI client package pipeline ([donations-api #18](https://github.com/jorgetroya80/donations-api/issues/18)). The backend now auto-generates and publishes `@jorgetroya80/donations-api-client` on every release. This Dependabot config closes the loop by notifying the frontend automatically.

