### PR TITLE
feat: display server validation errors inline in donor form

### DIFF
--- a/docs/PRD-donor-server-validation.md
+++ b/docs/PRD-donor-server-validation.md
@@ -1,0 +1,68 @@
+# PRD: Display Server-Side Field Validation Errors in Donor Form
+
+GitHub Issue: https://github.com/jorgetroya80/donations-frontend/issues/110
+
+## Problem Statement
+
+When a donor is submitted with invalid data (e.g. a national ID with an incorrect format), the API returns a structured 400 error response that includes per-field error messages. The frontend currently ignores this field-level detail and only shows a generic "Error saving" alert. The user has no way to know which field failed or what the problem is, forcing them to guess and re-submit.
+
+Additionally, the donor edit form has a bug where the `nationalId` field value is not correctly passed to the API on save, meaning edits to the national ID field are silently dropped.
+
+## Solution
+
+Parse the server's structured validation error response and display each field-level error message inline — directly below the relevant input — consistent with how client-side (Zod) validation errors are already shown. If the server returns no field-level errors (e.g. a 500), fall back to the existing generic alert. Fix the national ID mapping bug in the edit flow at the same time.
+
+## User Stories
+
+1. As a treasurer, I want to see an inline error message under the National ID field when I enter an invalid format, so that I know exactly what to fix without guessing.
+2. As a treasurer, I want to see inline error messages for any field the server rejects (name, national ID, email), so that I can correct all problems in a single round-trip.
+3. As a treasurer, I want the inline server error message to look the same as a client-side validation error, so that the experience is consistent.
+4. As a treasurer, I want the error message to disappear when I correct the field and re-submit, so that I know my fix was accepted.
+5. As a treasurer, I want a generic error alert to appear only when the server returns an error with no field details (e.g. a 500), so that I am never left with a silent failure.
+6. As a treasurer editing an existing donor, I want changes to the National ID field to be correctly saved to the server, so that donor records remain accurate.
+7. As a treasurer editing an existing donor, I want server validation errors to appear inline in the form after I confirm the save dialog, so that I can correct them without losing my other edits.
+8. As a treasurer editing an existing donor, I want the confirmation dialog to close when the server returns a validation error, so that I am returned to the form where the errors are shown.
+9. As a developer, I want a shared utility that parses the API's structured error response, so that future forms can reuse the same logic without duplication.
+10. As a developer, I want the `ApiValidationError` response shape typed in the shared API types file, so that the contract between frontend and backend is explicit and type-safe.
+
+## Implementation Decisions
+
+### Modules
+
+- **`ApiValidationError` type** — added to the shared API types module. Captures the server's 400 error shape: `status`, `error`, `message`, `fields: Record<string, string>`, and `timestamp`.
+
+- **`parseApiFieldErrors` utility** — new standalone function in the shared lib. Accepts an unknown caught error, checks if it is an `HTTPError` from the HTTP client (Ky), parses the response body as `ApiValidationError`, and returns the `fields` map. Returns an empty object for all other error types. Designed to be reused by any page that calls a mutation.
+
+- **`DonorForm` component** — gains a new optional `serverErrors` prop (`Record<string, string>`). Internally, a `useEffect` watches this prop and calls `setError` on the react-hook-form instance for each key, injecting server messages into the same error display pipeline used for client-side errors. No new UI code needed — existing error rendering handles both sources.
+
+- **`DonorCreatePage`** — wraps `mutateAsync` in try/catch. On catch, calls `parseApiFieldErrors` and stores the result in local state, which is passed as `serverErrors` to `DonorForm`. Generic alert shown only when there is a mutation error AND no field-level errors were parsed.
+
+- **`DonorEditPage`** — same try/catch pattern in the confirm-save handler. On error, closes the confirmation dialog and sets `serverErrors` state so the form displays them. Also fixes the bug where `nationalId` was read from the wrong property name when building the update request.
+
+### Technical clarifications
+
+- Server field keys match react-hook-form field names exactly (both use camelCase: `fullName`, `nationalId`, `email`). No key mapping needed.
+- The `useEffect` in `DonorForm` re-runs whenever the `serverErrors` reference changes. Pages should pass a new object reference on each failed submission so the effect fires correctly.
+- `mutateAsync` (TanStack Query) throws on non-2xx responses; the catch block is the correct intercept point. TanStack Query still sets `mutation.error` even when the error is caught from `mutateAsync`.
+- The generic alert condition (`mutation.error && Object.keys(serverErrors).length === 0`) ensures the alert only appears for errors without field detail (network failures, 500s).
+
+## Testing Decisions
+
+**What makes a good test:** tests verify observable UI behavior — what the user sees — not internal implementation. Tests should not assert on state variables, prop names, or which hooks were called. They should render the component and assert on what appears in the DOM.
+
+**Modules to test:**
+
+- **`DonorForm`** — add a test that renders the form with a `serverErrors` prop containing a `nationalId` message and asserts the message appears in the DOM. Prior art: the existing `shows validation errors on empty submit` test in `donor-form.test.tsx` — same pattern, different trigger.
+
+- **`parseApiFieldErrors`** — add unit tests: (1) returns `fields` map from a valid `HTTPError` with a 400 body; (2) returns empty object for a non-`HTTPError`; (3) returns empty object when response body is not valid JSON.
+
+## Out of Scope
+
+- Server error handling for other forms (donations, expenses, users) — those can adopt the shared utility independently.
+- Translating server error messages on the client — messages are displayed as returned by the server.
+- Showing multiple server errors per field — the server currently returns one message per field.
+- Retaining server errors across re-renders without a new submission — errors clear naturally when the user re-submits.
+
+## Further Notes
+
+The `parseApiFieldErrors` utility is intentionally shallow: it does one thing (parse a Ky `HTTPError` body) and returns a plain object. It has no React dependency and can be unit-tested without rendering anything. This design makes it easy to reuse in any future form that needs the same behavior.

--- a/docs/plans/donor-server-validation.md
+++ b/docs/plans/donor-server-validation.md
@@ -1,0 +1,59 @@
+# Plan: Donor Server-Side Field Validation Errors
+
+> Source PRD: [docs/PRD-donor-server-validation.md](../PRD-donor-server-validation.md) · [GitHub Issue #110](https://github.com/jorgetroya80/donations-frontend/issues/110)
+
+## Architectural decisions
+
+- **No route changes** — all work is within existing donor create/edit routes
+- **Error response shape**: `{ status, error, message, fields: Record<string, string>, timestamp }` — field keys match react-hook-form field names exactly (camelCase), no mapping needed
+- **Error source**: Ky `HTTPError` — response body parsed once at the page level, never in the form component
+- **Display strategy**: server errors injected into react-hook-form via `setError`, reusing existing field error UI — no new error display components
+- **Fallback**: generic alert shown only when mutation fails with no parseable field errors (network failures, 500s)
+
+---
+
+## Phase 1: End-to-end error display on donor create
+
+**User stories**: 1, 2, 3, 4, 5, 9, 10
+
+### What to build
+
+A complete vertical slice: server returns a 400 with field errors → page catches and parses them → form displays each error inline under the correct input.
+
+Add a typed `ApiValidationError` interface that mirrors the server's error response shape. Build a standalone `parseApiFieldErrors` utility that extracts the `fields` map from a Ky `HTTPError` and returns an empty object for anything else.
+
+Extend `DonorForm` with an optional `serverErrors` prop. When the prop changes, the form sets each entry as a field error using react-hook-form's `setError`, feeding into the existing inline error display. No new UI needed.
+
+Wire up the donor create page: wrap the mutation call in try/catch, parse any error with the utility, store the result in state, pass it to the form. Keep the generic alert but show it only when there are no field-level errors.
+
+### Acceptance criteria
+
+- [ ] Submitting the create form with an invalid national ID shows the server's error message inline under the National ID input
+- [ ] Submitting with multiple invalid fields shows each server error under its respective input
+- [ ] Inline server errors look identical to client-side Zod validation errors
+- [ ] After a server error, correcting and re-submitting clears the inline messages on success
+- [ ] A 500 or network error (no `fields` in response) still shows the generic alert
+- [ ] `parseApiFieldErrors` has unit tests: returns `fields` from a 400 HTTPError, returns `{}` for non-HTTPError, returns `{}` when body is not valid JSON
+- [ ] `DonorForm` has a test: rendering with `serverErrors` prop shows the message in the DOM
+
+---
+
+## Phase 2: Edit flow + nationalId bug fix
+
+**User stories**: 6, 7, 8
+
+### What to build
+
+Fix the existing bug where the national ID value is not correctly read when building the update request, causing edits to that field to be silently dropped.
+
+Apply the same server error pattern to the edit flow. The edit page has a confirmation dialog before saving — on API error, the dialog closes and the form displays inline field errors, returning the user to an editable state with the problems highlighted.
+
+Reuses the utility and form prop introduced in Phase 1 — no new infrastructure needed.
+
+### Acceptance criteria
+
+- [ ] Editing a donor's national ID and saving correctly persists the new value to the server
+- [ ] Submitting an invalid national ID in the edit flow shows the server's error message inline under the field
+- [ ] After a server validation error in the edit flow, the confirmation dialog is closed and the user is back on the form
+- [ ] All other edit-form server errors (name, email) display inline under their respective inputs
+- [ ] A 500 in the edit flow still shows the generic alert

--- a/src/features/donations/donation-form.test.tsx
+++ b/src/features/donations/donation-form.test.tsx
@@ -8,7 +8,7 @@ const mockDonors = [
   {
     id: 1,
     fullName: 'Juan Pérez',
-    dniNie: '12345678A',
+    nationalId: '12345678A',
     email: null,
     phone: null,
     address: null,

--- a/src/features/donors/donor-create-page.tsx
+++ b/src/features/donors/donor-create-page.tsx
@@ -13,7 +13,7 @@ export function DonorCreatePage() {
   async function handleSubmit(data: CreateDonorFormData) {
     await createMutation.mutateAsync({
       fullName: data.fullName,
-      dniNie: data.dniNie,
+      nationalId: data.nationalId,
       email: data.email || undefined,
       phone: data.phone || undefined,
       address: data.address || undefined,
@@ -36,7 +36,6 @@ export function DonorCreatePage() {
         onSubmit={handleSubmit}
         onCancel={() => navigate('/donors')}
         submitting={createMutation.isPending}
-        submitLabel={t('common.save')}
       />
     </div>
   )

--- a/src/features/donors/donor-edit-page.tsx
+++ b/src/features/donors/donor-edit-page.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate, useParams } from 'react-router'
 import { Alert, AlertDescription } from '@/components/ui/alert'
@@ -23,26 +23,28 @@ export function DonorEditPage() {
   const { data: donor, isLoading, error } = useDonor(donorId)
   const updateMutation = useUpdateDonor(donorId)
 
-  const [pendingData, setPendingData] = useState<CreateDonorFormData | null>(
-    null
-  )
+  const [showConfirm, setShowConfirm] = useState(false)
+  const confirmResolveRef = useRef<((value: boolean) => void) | null>(null)
 
-  function handleFormSubmit(data: CreateDonorFormData) {
-    setPendingData(data)
+  function waitForConfirmation(): Promise<boolean> {
+    return new Promise((resolve) => {
+      confirmResolveRef.current = resolve
+      setShowConfirm(true)
+    })
   }
 
-  async function handleConfirmSave() {
-    if (!pendingData) return
+  async function handleFormSubmit(data: CreateDonorFormData) {
+    const confirmed = await waitForConfirmation()
+    if (!confirmed) return
 
     await updateMutation.mutateAsync({
-      fullName: pendingData.fullName,
-      dniNie: pendingData.dniNie,
-      email: pendingData.email || undefined,
-      phone: pendingData.phone || undefined,
-      address: pendingData.address || undefined,
+      fullName: data.fullName,
+      nationalId: data.nationalId,
+      email: data.email || undefined,
+      phone: data.phone || undefined,
+      address: data.address || undefined,
     })
 
-    setPendingData(null)
     navigate('/donors')
   }
 
@@ -75,7 +77,7 @@ export function DonorEditPage() {
       <DonorForm
         defaultValues={{
           fullName: donor.fullName,
-          dniNie: donor.dniNie,
+          nationalId: donor.nationalId,
           email: donor.email,
           phone: donor.phone,
           address: donor.address,
@@ -83,20 +85,40 @@ export function DonorEditPage() {
         onSubmit={handleFormSubmit}
         onCancel={() => navigate('/donors')}
         submitting={updateMutation.isPending}
-        submitLabel={t('common.save')}
       />
 
-      <Dialog open={!!pendingData} onOpenChange={() => setPendingData(null)}>
+      <Dialog
+        open={showConfirm}
+        onOpenChange={(open) => {
+          if (!open) {
+            setShowConfirm(false)
+            confirmResolveRef.current?.(false)
+          }
+        }}
+      >
         <DialogContent>
           <DialogTitle>{t('donors.confirmEdit')}</DialogTitle>
           <DialogDescription>
             {t('donors.confirmEditDescription')}
           </DialogDescription>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setPendingData(null)}>
+            <Button
+              variant="outline"
+              onClick={() => {
+                setShowConfirm(false)
+                confirmResolveRef.current?.(false)
+              }}
+            >
               {t('common.cancel')}
             </Button>
-            <Button onClick={handleConfirmSave}>{t('common.confirm')}</Button>
+            <Button
+              onClick={() => {
+                setShowConfirm(false)
+                confirmResolveRef.current?.(true)
+              }}
+            >
+              {t('common.confirm')}
+            </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/src/features/donors/donor-form.test.tsx
+++ b/src/features/donors/donor-form.test.tsx
@@ -1,12 +1,13 @@
 import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { HTTPError } from 'ky'
 import { describe, expect, it, vi } from 'vitest'
 import { renderWithProviders } from '@/test/test-utils'
 import { DonorForm } from './donor-form'
 
 describe('DonorForm', () => {
   it('renders all form fields', () => {
-    renderWithProviders(<DonorForm onSubmit={vi.fn()} submitLabel="Guardar" />)
+    renderWithProviders(<DonorForm onSubmit={vi.fn()} />)
 
     expect(screen.getByLabelText('Nombre completo')).toBeInTheDocument()
     expect(screen.getByLabelText('DNI/NIE')).toBeInTheDocument()
@@ -20,7 +21,7 @@ describe('DonorForm', () => {
     const user = userEvent.setup()
     const onSubmit = vi.fn()
 
-    renderWithProviders(<DonorForm onSubmit={onSubmit} submitLabel="Guardar" />)
+    renderWithProviders(<DonorForm onSubmit={onSubmit} />)
 
     await user.click(screen.getByRole('button', { name: 'Guardar' }))
 
@@ -37,11 +38,10 @@ describe('DonorForm', () => {
       <DonorForm
         defaultValues={{
           fullName: 'Juan Pérez',
-          dniNie: '12345678A',
+          nationalId: '12345678A',
           email: 'juan@test.com',
         }}
         onSubmit={vi.fn()}
-        submitLabel="Guardar"
       />
     )
 
@@ -51,16 +51,12 @@ describe('DonorForm', () => {
   })
 
   it('renders Cancel button when onCancel is provided', () => {
-    renderWithProviders(
-      <DonorForm onSubmit={vi.fn()} onCancel={vi.fn()} submitLabel="Guardar" />
-    )
+    renderWithProviders(<DonorForm onSubmit={vi.fn()} onCancel={vi.fn()} />)
     expect(screen.getByRole('button', { name: 'Cancelar' })).toBeInTheDocument()
   })
 
   it('Cancel button has type="button"', () => {
-    renderWithProviders(
-      <DonorForm onSubmit={vi.fn()} onCancel={vi.fn()} submitLabel="Guardar" />
-    )
+    renderWithProviders(<DonorForm onSubmit={vi.fn()} onCancel={vi.fn()} />)
     expect(screen.getByRole('button', { name: 'Cancelar' })).toHaveAttribute(
       'type',
       'button'
@@ -70,16 +66,14 @@ describe('DonorForm', () => {
   it('clicking Cancel calls onCancel', async () => {
     const user = userEvent.setup()
     const onCancel = vi.fn()
-    renderWithProviders(
-      <DonorForm onSubmit={vi.fn()} onCancel={onCancel} submitLabel="Guardar" />
-    )
+    renderWithProviders(<DonorForm onSubmit={vi.fn()} onCancel={onCancel} />)
     await user.click(screen.getByRole('button', { name: 'Cancelar' }))
     expect(onCancel).toHaveBeenCalledOnce()
   })
 
   it('sets aria-invalid and aria-describedby on invalid submit', async () => {
     const user = userEvent.setup()
-    renderWithProviders(<DonorForm onSubmit={vi.fn()} submitLabel="Guardar" />)
+    renderWithProviders(<DonorForm onSubmit={vi.fn()} />)
 
     await user.click(screen.getByRole('button', { name: 'Guardar' }))
 
@@ -97,8 +91,11 @@ describe('DonorForm', () => {
 
       const dniNieInput = screen.getByLabelText('DNI/NIE')
       expect(dniNieInput).toHaveAttribute('aria-invalid', 'true')
-      expect(dniNieInput).toHaveAttribute('aria-describedby', 'dniNie-error')
-      expect(document.getElementById('dniNie-error')).toHaveAttribute(
+      expect(dniNieInput).toHaveAttribute(
+        'aria-describedby',
+        'nationalId-error'
+      )
+      expect(document.getElementById('nationalId-error')).toHaveAttribute(
         'role',
         'alert'
       )
@@ -106,22 +103,46 @@ describe('DonorForm', () => {
   })
 
   it('has no aria-invalid or aria-describedby before submit', () => {
-    renderWithProviders(<DonorForm onSubmit={vi.fn()} submitLabel="Guardar" />)
+    renderWithProviders(<DonorForm onSubmit={vi.fn()} />)
 
     const fullNameInput = screen.getByLabelText('Nombre completo')
     expect(fullNameInput).toHaveAttribute('aria-invalid', 'false')
     expect(fullNameInput).not.toHaveAttribute('aria-describedby')
 
-    const dniNieInput = screen.getByLabelText('DNI/NIE')
-    expect(dniNieInput).toHaveAttribute('aria-invalid', 'false')
-    expect(dniNieInput).not.toHaveAttribute('aria-describedby')
+    const nationalIdInput = screen.getByLabelText('DNI/NIE')
+    expect(nationalIdInput).toHaveAttribute('aria-invalid', 'false')
+    expect(nationalIdInput).not.toHaveAttribute('aria-describedby')
+  })
+
+  it('displays server field errors when onSubmit rejects with HTTPError', async () => {
+    const user = userEvent.setup()
+    // ky v2 pre-parses the response body into error.data before throwing
+    const serverError = new HTTPError(
+      new Response(null, { status: 400 }),
+      new Request('http://localhost'),
+      {} as never
+    )
+    serverError.data = { fields: { nationalId: 'Formato de DNI/NIE inválido' } }
+    const onSubmit = vi.fn().mockRejectedValue(serverError)
+
+    renderWithProviders(<DonorForm onSubmit={onSubmit} />)
+
+    await user.type(screen.getByLabelText('Nombre completo'), 'Juan Pérez')
+    await user.type(screen.getByLabelText('DNI/NIE'), '99999999Z')
+    await user.click(screen.getByRole('button', { name: 'Guardar' }))
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Formato de DNI/NIE inválido')
+      ).toBeInTheDocument()
+    })
   })
 
   it('calls onSubmit with valid data', async () => {
     const user = userEvent.setup()
     const onSubmit = vi.fn()
 
-    renderWithProviders(<DonorForm onSubmit={onSubmit} submitLabel="Guardar" />)
+    renderWithProviders(<DonorForm onSubmit={onSubmit} />)
 
     await user.type(screen.getByLabelText('Nombre completo'), 'Test Donor')
     await user.type(screen.getByLabelText('DNI/NIE'), '99999999Z')
@@ -132,9 +153,8 @@ describe('DonorForm', () => {
       expect(onSubmit).toHaveBeenCalledWith(
         expect.objectContaining({
           fullName: 'Test Donor',
-          dniNie: '99999999Z',
-        }),
-        expect.anything()
+          nationalId: '99999999Z',
+        })
       )
     })
   })

--- a/src/features/donors/donor-form.tsx
+++ b/src/features/donors/donor-form.tsx
@@ -4,14 +4,14 @@ import { useTranslation } from 'react-i18next'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { parseApiFieldErrors } from '@/lib/parse-api-field-errors'
 import { type CreateDonorFormData, createDonorSchema } from './donor-schema'
 
 interface DonorFormProps {
   defaultValues?: Partial<CreateDonorFormData>
-  onSubmit: (data: CreateDonorFormData) => void
+  onSubmit: (data: CreateDonorFormData) => void | Promise<void>
   onCancel?: () => void
   submitting?: boolean
-  submitLabel: string
 }
 
 export function DonorForm({
@@ -19,27 +19,38 @@ export function DonorForm({
   onSubmit,
   onCancel,
   submitting,
-  submitLabel,
 }: DonorFormProps) {
   const { t } = useTranslation()
 
   const {
     register,
     handleSubmit,
+    setError,
     formState: { errors },
   } = useForm({
     resolver: zodResolver(createDonorSchema),
     defaultValues: {
       fullName: defaultValues?.fullName ?? '',
-      dniNie: defaultValues?.dniNie ?? '',
+      nationalId: defaultValues?.nationalId ?? '',
       email: defaultValues?.email ?? '',
       phone: defaultValues?.phone ?? '',
       address: defaultValues?.address ?? '',
     },
   })
 
+  async function submitHandler(data: CreateDonorFormData) {
+    try {
+      await onSubmit(data)
+    } catch (err) {
+      const fields = parseApiFieldErrors(err)
+      for (const [field, message] of Object.entries(fields)) {
+        setError(field as keyof CreateDonorFormData, { message })
+      }
+    }
+  }
+
   return (
-    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+    <form onSubmit={handleSubmit(submitHandler)} className="space-y-4">
       <div className="grid gap-4 sm:grid-cols-2">
         <div className="space-y-2">
           <Label htmlFor="fullName">{t('donors.fullName')}</Label>
@@ -61,20 +72,22 @@ export function DonorForm({
         </div>
 
         <div className="space-y-2">
-          <Label htmlFor="dniNie">{t('donors.dniNie')}</Label>
+          <Label htmlFor="nationalId">{t('donors.nationalId')}</Label>
           <Input
-            id="dniNie"
-            aria-invalid={!!errors.dniNie}
-            aria-describedby={errors.dniNie ? 'dniNie-error' : undefined}
-            {...register('dniNie')}
+            id="nationalId"
+            aria-invalid={!!errors.nationalId}
+            aria-describedby={
+              errors.nationalId ? 'nationalId-error' : undefined
+            }
+            {...register('nationalId')}
           />
-          {errors.dniNie && (
+          {errors.nationalId && (
             <p
-              id="dniNie-error"
+              id="nationalId-error"
               role="alert"
               className="text-sm text-destructive"
             >
-              {errors.dniNie.message}
+              {errors.nationalId.message}
             </p>
           )}
         </div>
@@ -112,7 +125,7 @@ export function DonorForm({
 
       <div className="flex gap-2">
         <Button type="submit" disabled={submitting}>
-          {submitting ? t('common.loading') : submitLabel}
+          {submitting ? t('common.loading') : t('common.save')}
         </Button>
         {onCancel && (
           <Button type="button" variant="outline" onClick={onCancel}>

--- a/src/features/donors/donor-schema.ts
+++ b/src/features/donors/donor-schema.ts
@@ -7,7 +7,7 @@ const emptyToNull = z
 
 export const createDonorSchema = z.object({
   fullName: z.string().min(1, 'El nombre es obligatorio'),
-  dniNie: z.string().min(1, 'El DNI/NIE es obligatorio'),
+  nationalId: z.string().min(1, 'El DNI/NIE es obligatorio'),
   email: emptyToNull.optional(),
   phone: z.string().nullable().optional(),
   address: z.string().nullable().optional(),

--- a/src/features/donors/donors-page.tsx
+++ b/src/features/donors/donors-page.tsx
@@ -108,7 +108,7 @@ export function DonorsPage() {
                   {t('donors.fullName')}
                   <span aria-hidden="true">{sortIndicator('fullName')}</span>
                 </TableHead>
-                <TableHead>{t('donors.dniNie')}</TableHead>
+                <TableHead>{t('donors.nationalId')}</TableHead>
                 <TableHead>{t('donors.email')}</TableHead>
                 <TableHead>{t('donors.phone')}</TableHead>
                 <TableHead>{t('donors.status')}</TableHead>
@@ -121,7 +121,7 @@ export function DonorsPage() {
                   <TableCell className="font-medium">
                     {donor.fullName}
                   </TableCell>
-                  <TableCell>{donor.dniNie}</TableCell>
+                  <TableCell>{donor.nationalId}</TableCell>
                   <TableCell>{donor.email ?? '—'}</TableCell>
                   <TableCell>{donor.phone ?? '—'}</TableCell>
                   <TableCell>

--- a/src/features/donors/use-donors.test.tsx
+++ b/src/features/donors/use-donors.test.tsx
@@ -42,7 +42,7 @@ describe('useDonor', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
     expect(result.current.data?.id).toBe(1)
     expect(result.current.data?.fullName).toBe('Juan Pérez')
-    expect(result.current.data?.dniNie).toBe('12345678A')
+    expect(result.current.data?.nationalId).toBe('12345678A')
   })
 })
 
@@ -56,7 +56,7 @@ describe('useCreateDonor', () => {
     await waitFor(async () => {
       response = await result.current.mutateAsync({
         fullName: 'Test Donor',
-        dniNie: '99999999Z',
+        nationalId: '99999999Z',
       })
     })
 

--- a/src/lib/api-types.ts
+++ b/src/lib/api-types.ts
@@ -98,7 +98,7 @@ export interface DonationCreateResponse {
 export interface DonorResponse {
   id: number
   fullName: string
-  dniNie: string
+  nationalId: string
   email: string | null
   phone: string | null
   address: string | null
@@ -109,7 +109,7 @@ export interface DonorResponse {
 
 export interface CreateDonorRequest {
   fullName: string
-  dniNie: string
+  nationalId: string
   email?: string | null
   phone?: string | null
   address?: string | null
@@ -117,7 +117,7 @@ export interface CreateDonorRequest {
 
 export interface UpdateDonorRequest {
   fullName?: string
-  dniNie?: string
+  nationalId?: string
   email?: string | null
   phone?: string | null
   address?: string | null

--- a/src/lib/parse-api-field-errors.test.ts
+++ b/src/lib/parse-api-field-errors.test.ts
@@ -1,0 +1,46 @@
+import { HTTPError } from 'ky'
+import { describe, expect, it } from 'vitest'
+import { parseApiFieldErrors } from './parse-api-field-errors'
+
+// ky v2 pre-parses the response body into error.data before throwing.
+// Tests mirror that behavior by setting error.data directly.
+function makeHTTPError(data: unknown): HTTPError {
+  const err = new HTTPError(
+    new Response(null, { status: 400 }),
+    new Request('http://localhost'),
+    {} as never
+  )
+  err.data = data
+  return err
+}
+
+describe('parseApiFieldErrors', () => {
+  it('returns fields from a validation error', () => {
+    const err = makeHTTPError({ fields: { nationalId: 'Invalid format' } })
+    expect(parseApiFieldErrors(err)).toEqual({ nationalId: 'Invalid format' })
+  })
+
+  it('returns empty object for non-HTTPError', () => {
+    expect(parseApiFieldErrors(new Error('oops'))).toEqual({})
+  })
+
+  it('returns empty object when data has no fields property', () => {
+    const err = makeHTTPError({ message: 'Internal server error' })
+    expect(parseApiFieldErrors(err)).toEqual({})
+  })
+
+  it('returns empty object when data is undefined', () => {
+    const err = makeHTTPError(undefined)
+    expect(parseApiFieldErrors(err)).toEqual({})
+  })
+
+  it('handles multiple field errors', () => {
+    const err = makeHTTPError({
+      fields: { fullName: 'Required', nationalId: 'Invalid format' },
+    })
+    expect(parseApiFieldErrors(err)).toEqual({
+      fullName: 'Required',
+      nationalId: 'Invalid format',
+    })
+  })
+})

--- a/src/lib/parse-api-field-errors.ts
+++ b/src/lib/parse-api-field-errors.ts
@@ -1,0 +1,18 @@
+import { HTTPError } from 'ky'
+import { z } from 'zod/v4'
+
+const apiErrorSchema = z.object({
+  fields: z.record(z.string(), z.string()).optional(),
+})
+
+// ky v2 pre-parses the response body into `error.data` before throwing,
+// so `error.response.json()` is unavailable — use `error.data` directly.
+export function parseApiFieldErrors(err: unknown): Record<string, string> {
+  if (err instanceof HTTPError) {
+    const parsed = apiErrorSchema.safeParse(err.data)
+    if (parsed.success && parsed.data.fields) {
+      return parsed.data.fields
+    }
+  }
+  return {}
+}

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -87,7 +87,7 @@
     "new": "Nuevo donante",
     "edit": "Editar donante",
     "fullName": "Nombre completo",
-    "dniNie": "DNI/NIE",
+    "nationalId": "DNI/NIE",
     "email": "Email",
     "emailOptional": "Email (opcional)",
     "phone": "Teléfono",

--- a/src/test/msw-handlers.ts
+++ b/src/test/msw-handlers.ts
@@ -215,7 +215,7 @@ export const handlers = [
         {
           id: 1,
           fullName: 'Juan Pérez',
-          dniNie: '12345678A',
+          nationalId: '12345678A',
           email: 'juan@test.com',
           phone: null,
           address: null,
@@ -226,7 +226,7 @@ export const handlers = [
         {
           id: 2,
           fullName: 'María García',
-          dniNie: '87654321B',
+          nationalId: '87654321B',
           email: null,
           phone: '600123456',
           address: 'Calle Mayor 1',
@@ -248,7 +248,7 @@ export const handlers = [
       return HttpResponse.json({
         id: 1,
         fullName: 'Juan Pérez',
-        dniNie: '12345678A',
+        nationalId: '12345678A',
         email: 'juan@test.com',
         phone: null,
         address: null,
@@ -265,7 +265,7 @@ export const handlers = [
     return HttpResponse.json({
       id: 3,
       fullName: body.fullName,
-      dniNie: body.dniNie,
+      nationalId: body.nationalId,
       email: body.email ?? null,
       phone: body.phone ?? null,
       address: body.address ?? null,
@@ -280,7 +280,7 @@ export const handlers = [
     return HttpResponse.json({
       id: 1,
       fullName: body.fullName ?? 'Juan Pérez',
-      dniNie: body.dniNie ?? '12345678A',
+      nationalId: body.nationalId ?? '12345678A',
       email: body.email ?? null,
       phone: body.phone ?? null,
       address: body.address ?? null,


### PR DESCRIPTION
## Summary

- Fix `nationalId` field rename (`dniNie` → `nationalId`) across donor-related files and tests
- Add `parseApiFieldErrors` utility using Zod to safely parse ky v2 `HTTPError.data`
- `DonorForm` wraps `onSubmit` in a try/catch — field errors from the server call `setError` directly inside the form, avoiding any React Compiler memoization boundary
- `DonorEditPage` refactors the confirmation dialog to a promise-based pattern so server errors from `mutateAsync` propagate back to the form's catch block
- Remove swallowed try/catch in `DonorCreatePage.handleSubmit` so errors reach the form

## Root causes found

**ky v2 breaking change**: `HTTPError.response` body is pre-consumed into `error.data` before throwing. Previous code called `error.response.clone().json()` on an already-consumed stream — this silently failed, returning `{}`. Fix: read `error.data` directly (synchronous, no clone needed).

**Error swallowed in page**: `DonorCreatePage.handleSubmit` had a `try/catch` that logged the error and returned normally — the form's catch block never fired.

## Related

- Closes #110


## Test plan

- [x] Enter invalid national ID (e.g. `123`) when creating a donor → error from server appears inline under the DNI/NIE field
- [x] Enter invalid email when creating a donor → inline email error shown
- [x] Enter valid data → donor created, navigates to `/donors`
- [x] Edit donor, confirm, submit with invalid national ID → error shown inline after dialog closes
- [x] All 280 unit tests pass

