### PR TITLE
fix: authenticate to GitHub Packages in Docker build

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -36,6 +36,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          secrets: |
+            NODE_AUTH_TOKEN=${{ secrets.JSR_AUTH_TOKEN }}
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/donations-frontend:${{ inputs.version }}
             ${{ secrets.DOCKERHUB_USERNAME }}/donations-frontend:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,10 @@ WORKDIR /app
 
 RUN corepack enable && corepack prepare pnpm@11.1.1 --activate
 
-COPY pnpm-lock.yaml ./
+COPY pnpm-lock.yaml .npmrc ./
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store \
-    pnpm fetch
+    --mount=type=secret,id=NODE_AUTH_TOKEN \
+    NODE_AUTH_TOKEN=$(cat /run/secrets/NODE_AUTH_TOKEN) pnpm fetch
 
 COPY package.json pnpm-workspace.yaml ./
 RUN pnpm install --frozen-lockfile --offline

--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ cd ~/donations && ./scripts/start.sh
 
 Open **http://localhost:8080** in your browser.
 
-| Script | What it does |
-|---|---|
-| `./scripts/start.sh` | Start the app |
-| `./scripts/stop.sh` | Stop the app (data is kept) |
-| `./scripts/update.sh` | Update to the latest version |
-| `./scripts/reset.sh` | Wipe database and start fresh |
+| Script                | What it does                  |
+| --------------------- | ----------------------------- |
+| `./scripts/start.sh`  | Start the app                 |
+| `./scripts/stop.sh`   | Stop the app (data is kept)   |
+| `./scripts/update.sh` | Update to the latest version  |
+| `./scripts/reset.sh`  | Wipe database and start fresh |
 
 ---
 
@@ -49,8 +49,8 @@ App runs at http://localhost:3000
 
 ## Scripts
 
-| Command                 | Description             |
-| ----------------------- | ----------------------- |
+| Command                  | Description             |
+| ------------------------ | ----------------------- |
 | `pnpm run dev`           | Start dev server        |
 | `pnpm run build`         | Production build        |
 | `pnpm run test`          | Run tests               |
@@ -68,7 +68,12 @@ App runs at http://localhost:3000
    cp .env.example .env
    ```
 
-   Defaults work out of the box — no edits needed for local development.
+   Export `NODE_AUTH_TOKEN` (a GitHub Personal Access Token with **`read:packages`** scope) in your shell profile so it's available to Docker Compose during the build:
+
+   ```bash
+   # Add once to ~/.zshrc or ~/.bashrc
+   export NODE_AUTH_TOKEN=ghp_yourtoken
+   ```
 
 2. Start API and frontend:
 
@@ -78,19 +83,20 @@ App runs at http://localhost:3000
 
 App runs at http://localhost:8080
 
-| Command | Effect |
-|---|---|
+| Command                     | Effect                         |
+| --------------------------- | ------------------------------ |
 | `docker compose up --build` | Start + rebuild frontend image |
-| `docker compose down` | Stop (data persists) |
-| `docker compose down -v` | Stop + wipe database |
-| `docker compose pull` | Pull latest API image |
+| `docker compose down`       | Stop (data persists)           |
+| `docker compose down -v`    | Stop + wipe database           |
+| `docker compose pull`       | Pull latest API image          |
 
 ## Docker (frontend only)
 
-Requires the API already running on port 8081.
+Requires the API already running on port 8081. Requires a GitHub PAT with `read:packages` scope exported as `NODE_AUTH_TOKEN`.
 
 ```bash
-docker build -t donations-frontend .
+export NODE_AUTH_TOKEN=your_token
+docker build --secret id=NODE_AUTH_TOKEN,env=NODE_AUTH_TOKEN -t donations-frontend .
 docker run --name donations-frontend --rm -p 8080:80 --add-host=api:host-gateway donations-frontend
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
       context: .
       args:
         VITE_API_URL: ${VITE_API_URL:-}
+      secrets:
+        - node_auth_token
     ports:
       - '8080:80'
     depends_on:
@@ -70,3 +72,7 @@ networks:
 
 volumes:
   postgres-data-prod:
+
+secrets:
+  node_auth_token:
+    environment: NODE_AUTH_TOKEN


### PR DESCRIPTION
## Summary

- Replace `build-args` (which leaked the token into image history) with BuildKit `--mount=type=secret` in `Dockerfile` — token is never baked into any layer
- Fix `docker-publish.yml`: switch from `build-args` to `secrets` input in `docker/build-push-action`, mapping `JSR_AUTH_TOKEN` → `NODE_AUTH_TOKEN` to match what `.npmrc` expects
- Copy `.npmrc` into the build stage before `pnpm fetch` so the registry config is available
- Add build secrets config to `docker-compose.yml` so `docker compose up --build` picks up `NODE_AUTH_TOKEN` from the host environment
- Update README local-build sections with token requirement and correct commands


