### PR TITLE
feat(reports): replace donor select with Autocomplete for large donor lists

### DIFF
--- a/docs/plans/report-donor-autocomplete.md
+++ b/docs/plans/report-donor-autocomplete.md
@@ -1,0 +1,168 @@
+# Spec: Replace Donor Select with Combobox in Reports
+
+## Context
+
+`DonorStatementTab` in `src/features/reports/reports-page.tsx` uses a plain `<select>` to pick a donor before loading their statement. For large donor lists this becomes unusable — all donors are crammed into a dropdown with no way to search. The fix: replace the `<select>` with a type-to-search combobox that filters donors by name as the user types.
+
+The existing `useDonors()` hook (in `use-donations.ts`) already fetches up to 100 donors sorted by name — no API changes needed. The donor statement total already appears in the statement table — no new data required.
+
+## Success Criteria
+
+- `<select>` in `DonorStatementTab` is gone
+- Text input lets user type a name; matching donors appear in a filtered dropdown
+- Filtering is case-insensitive substring match on `fullName`
+- Selecting a donor from the dropdown populates the input and loads their statement (same as before)
+- Keyboard: `↑`/`↓` navigate options, `Enter` selects, `Escape` closes
+- Clicking outside closes the dropdown
+- Shows "No results" message when filter matches nothing
+- Existing statement rendering (date, type, payment method, amount, grand total) unchanged
+- `pnpm run check` passes (no TS errors, no lint issues)
+
+## Approach
+
+Use `Autocomplete` from `@base-ui/react` (v1.4.1, already installed). Replace the `<select>` in `DonorStatementTab` inline — no new file/component needed.
+
+**State change**: remove the `select`'s `onChange` handler; keep only `donorId` state. The autocomplete handles input internally.
+
+**Key Base-UI parts used**:
+- `Autocomplete.Root` — wraps everything; receives `items={donors}` and `itemToStringValue={(d) => d.fullName ?? ''}`
+- `Autocomplete.InputGroup` + `Autocomplete.Input` — the text input
+- `Autocomplete.Positioner` → `Autocomplete.Popup` → `Autocomplete.List` — dropdown
+- `Autocomplete.Item value={donor}` — each donor row, with `onClick={() => setDonorId(donor.id ?? null)}`
+- `Autocomplete.Empty` — renders when no items match
+- `Autocomplete.useFilteredItems<DonorResponse>()` — hook to get filtered list inside a child component
+
+**Filtering**: `mode='list'` (default) — Base-UI filters items automatically by `itemToStringValue` string as user types.
+
+**Clearing donorId**: use `onValueChange` on `Autocomplete.Root` — when value becomes `''`, call `setDonorId(null)`.
+
+**Inner list component** (needed because `useFilteredItems` must be called inside `Autocomplete.Root`):
+```tsx
+function DonorList({ onSelect }: { onSelect: (id: number) => void }) {
+  const filtered = Autocomplete.useFilteredItems<DonorResponse>()
+  return (
+    <Autocomplete.List>
+      {filtered.map((donor, i) => (
+        <Autocomplete.Item key={donor.id} value={donor} index={i}
+          onClick={() => onSelect(donor.id ?? 0)}>
+          {donor.fullName} — {donor.nationalId}
+        </Autocomplete.Item>
+      ))}
+    </Autocomplete.List>
+  )
+}
+```
+
+Style all Base-UI parts with Tailwind classes (no wrapper component).
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `src/features/reports/reports-page.tsx` | Replace `<select>` with `Autocomplete` in `DonorStatementTab`; add `DonorList` sub-component |
+| `src/locales/es.json` | Add `reports.searchDonor` and `reports.noDonorsFound` |
+
+## New i18n Keys
+
+```json
+"searchDonor": "Buscar donante...",
+"noDonorsFound": "No se encontraron donantes"
+```
+
+## Implementation Steps
+
+1. Add `import { Autocomplete } from '@base-ui/react'` to `reports-page.tsx`
+2. Define `DonorList` sub-component above `DonorStatementTab` using `Autocomplete.useFilteredItems`
+3. In `DonorStatementTab`: replace `<select>...</select>` with:
+   ```tsx
+   <Autocomplete.Root
+     items={donors}
+     itemToStringValue={(d) => d.fullName ?? ''}
+     onValueChange={(v) => { if (!v) setDonorId(null) }}
+   >
+     <Autocomplete.InputGroup>
+       <Autocomplete.Input placeholder={t('reports.searchDonor')} className="..." />
+     </Autocomplete.InputGroup>
+     <Autocomplete.Positioner>
+       <Autocomplete.Popup className="...">
+         <DonorList onSelect={setDonorId} />
+         <Autocomplete.Empty className="...">{t('reports.noDonorsFound')}</Autocomplete.Empty>
+       </Autocomplete.Popup>
+     </Autocomplete.Positioner>
+   </Autocomplete.Root>
+   ```
+4. Style with Tailwind to match existing form inputs (`rounded-md border border-input bg-background px-3 py-2 text-sm`)
+5. Add the two i18n keys to `es.json`
+
+## Task Breakdown
+
+### Task 1 — Add i18n keys (XS)
+
+**Description:** Add the two new translation strings needed by the autocomplete UI.
+
+**Acceptance criteria:**
+- [ ] `reports.searchDonor` = `"Buscar donante..."` exists in `es.json`
+- [ ] `reports.noDonorsFound` = `"No se encontraron donantes"` exists in `es.json`
+
+**Verification:**
+- [ ] `pnpm run check` passes
+
+**Dependencies:** None
+
+**Files:** `src/locales/es.json`
+
+**Scope:** XS
+
+---
+
+### Task 2 — Add `DonorList` sub-component (S)
+
+**Description:** Define `DonorList` above `DonorStatementTab`. Calls `Autocomplete.useFilteredItems<DonorResponse>()` and renders the filtered donor list. Add `Autocomplete` import at the top.
+
+**Acceptance criteria:**
+- [ ] `import { Autocomplete } from '@base-ui/react'` added
+- [ ] `DonorList` renders `Autocomplete.List` with one `Autocomplete.Item` per filtered donor, showing `fullName — nationalId`
+- [ ] Each item fires `onSelect(donor.id)` via `onClick`
+- [ ] No TypeScript errors
+
+**Verification:**
+- [ ] `pnpm run check` passes
+
+**Dependencies:** Task 1
+
+**Files:** `src/features/reports/reports-page.tsx`
+
+**Scope:** S
+
+---
+
+### Task 3 — Replace `<select>` with `Autocomplete.Root` (S)
+
+**Description:** In `DonorStatementTab`, remove the `<select>` block and replace with the full `Autocomplete` tree. Wire `donorId` state: items' `onClick` sets it (via `DonorList`), and `onValueChange` clears it when input is emptied.
+
+**Acceptance criteria:**
+- [ ] `<select>` is gone
+- [ ] `Autocomplete.Root` wraps `InputGroup` + `Positioner → Popup → (DonorList + Empty)`
+- [ ] Typing filters donors; selecting one loads their statement
+- [ ] Clearing input hides statement (`donorId` → `null`)
+- [ ] `Autocomplete.Empty` shows `t('reports.noDonorsFound')` when no donors match
+- [ ] Styles match existing inputs (`rounded-md border border-input bg-background px-3 py-2 text-sm`)
+
+**Verification:**
+- [ ] `pnpm run check` passes
+- [ ] `pnpm run test` passes (existing tests unchanged)
+- [ ] Manual: `pnpm run dev` → Reports → Donor Statement → type name → select → statement loads
+
+**Dependencies:** Task 2
+
+**Files:** `src/features/reports/reports-page.tsx`
+
+**Scope:** S
+
+---
+
+### Checkpoint: Done
+
+- [ ] `pnpm run check` — no TS or lint errors
+- [ ] `pnpm run test` — all existing tests green
+- [ ] Manual golden path: type → filter → select → statement loads → clear → statement hides

--- a/src/features/reports/reports-page.test.tsx
+++ b/src/features/reports/reports-page.test.tsx
@@ -81,9 +81,7 @@ describe('ReportsPage', () => {
     await user.type(input, 'zzznomatch')
 
     await waitFor(() => {
-      expect(
-        screen.getByText('No se encontraron donantes')
-      ).toBeInTheDocument()
+      expect(screen.getByText('No se encontraron donantes')).toBeInTheDocument()
     })
   })
 

--- a/src/features/reports/reports-page.test.tsx
+++ b/src/features/reports/reports-page.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it } from 'vitest'
 import { renderWithProviders } from '@/test/test-utils'
@@ -36,33 +36,35 @@ describe('ReportsPage', () => {
     expect(screen.getByText('Servicios')).toBeInTheDocument()
   })
 
-  it('switches to donor statement tab and shows donor selector', async () => {
+  it('switches to donor statement tab and shows autocomplete input', async () => {
     const user = userEvent.setup()
     renderPage()
     await user.click(screen.getByText('Estado de cuenta del donante'))
     expect(
       screen.getByText('Seleccione un donante para ver su estado de cuenta')
     ).toBeInTheDocument()
-    expect(screen.getByLabelText('Seleccione un donante')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Buscar donante...')).toBeInTheDocument()
   })
 
-  it('loads donor statement when donor selected', async () => {
+  it('loads donor statement when donor selected from autocomplete', async () => {
+    const user = userEvent.setup()
     renderPage()
-    // Switch to donor statement tab
-    fireEvent.click(screen.getByText('Estado de cuenta del donante'))
+    await user.click(screen.getByText('Estado de cuenta del donante'))
 
-    // Wait for donors to load in selector
-    const select = screen.getByLabelText(
-      'Seleccione un donante'
-    ) as HTMLSelectElement
+    const input = screen.getByPlaceholderText('Buscar donante...')
+
+    // Type to filter donors
+    await user.type(input, 'Juan')
+
+    // Donor option appears
     await waitFor(() => {
-      expect(select.options.length).toBeGreaterThan(1)
+      expect(screen.getByText('Juan Pérez — 12345678A')).toBeInTheDocument()
     })
 
-    // Select donor
-    fireEvent.change(select, { target: { value: '1' } })
+    // Click donor option
+    await user.click(screen.getByText('Juan Pérez — 12345678A'))
 
-    // Wait for statement table to render (proves data loaded)
+    // Statement loads
     await waitFor(() => {
       expect(screen.getByText('Diezmo')).toBeInTheDocument()
     })

--- a/src/features/reports/reports-page.test.tsx
+++ b/src/features/reports/reports-page.test.tsx
@@ -72,6 +72,50 @@ describe('ReportsPage', () => {
     expect(screen.getByText('Total general')).toBeInTheDocument()
   })
 
+  it('shows no donors found message when search matches nothing', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await user.click(screen.getByText('Estado de cuenta del donante'))
+
+    const input = screen.getByPlaceholderText('Buscar donante...')
+    await user.type(input, 'zzznomatch')
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('No se encontraron donantes')
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('hides statement when input is cleared after donor selected', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await user.click(screen.getByText('Estado de cuenta del donante'))
+
+    const input = screen.getByPlaceholderText('Buscar donante...')
+    await user.type(input, 'Juan')
+
+    await waitFor(() => {
+      expect(screen.getByText('Juan Pérez — 12345678A')).toBeInTheDocument()
+    })
+    await user.click(screen.getByText('Juan Pérez — 12345678A'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Diezmo')).toBeInTheDocument()
+    })
+
+    // Clear the input
+    await user.clear(input)
+
+    // Statement should be hidden; prompt message should reappear
+    await waitFor(() => {
+      expect(screen.queryByText('Diezmo')).not.toBeInTheDocument()
+    })
+    expect(
+      screen.getByText('Seleccione un donante para ver su estado de cuenta')
+    ).toBeInTheDocument()
+  })
+
   it('shows active tab styling', () => {
     renderPage()
     const donationsTab = screen.getByRole('tab', {

--- a/src/features/reports/reports-page.tsx
+++ b/src/features/reports/reports-page.tsx
@@ -1,3 +1,5 @@
+import { Autocomplete } from '@base-ui/react'
+import type { DonorResponse } from '@jorgetroya80/donations-api-client'
 import dayjs from 'dayjs'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -164,6 +166,25 @@ function ExpenseSummaryTab() {
   )
 }
 
+function DonorList({ onSelect }: { onSelect: (id: number) => void }) {
+  const filtered = Autocomplete.useFilteredItems<DonorResponse>()
+  return (
+    <Autocomplete.List>
+      {filtered.map((donor, i) => (
+        <Autocomplete.Item
+          key={donor.id}
+          value={donor}
+          index={i}
+          onClick={() => onSelect(donor.id ?? 0)}
+          className="cursor-pointer px-3 py-2 text-sm data-[highlighted]:bg-accent"
+        >
+          {donor.fullName} — {donor.nationalId}
+        </Autocomplete.Item>
+      ))}
+    </Autocomplete.List>
+  )
+}
+
 function DonorStatementTab() {
   const { t } = useTranslation()
   const [range, setRange] = useState(currentMonthRange)
@@ -179,22 +200,30 @@ function DonorStatementTab() {
   return (
     <div className="space-y-4">
       <div className="flex flex-wrap items-center gap-4">
-        <select
-          value={donorId ?? ''}
-          onChange={(e) => {
-            const val = e.target.value
-            setDonorId(val ? Number(val) : null)
+        <Autocomplete.Root
+          items={donors}
+          itemToStringValue={(d: DonorResponse) => d.fullName ?? ''}
+          onValueChange={(v) => {
+            if (!v) setDonorId(null)
           }}
-          className="rounded-md border border-input bg-background px-3 py-2 text-sm"
-          aria-label={t('reports.selectDonor')}
         >
-          <option value="">{t('reports.selectDonor')}</option>
-          {donors.map((d) => (
-            <option key={d.id} value={d.id}>
-              {d.fullName}
-            </option>
-          ))}
-        </select>
+          <Autocomplete.InputGroup>
+            <Autocomplete.Input
+              placeholder={t('reports.searchDonor')}
+              className="rounded-md border border-input bg-background px-3 py-2 text-sm"
+            />
+          </Autocomplete.InputGroup>
+          <Autocomplete.Portal>
+            <Autocomplete.Positioner>
+              <Autocomplete.Popup className="z-50 min-w-48 rounded-md border border-input bg-background shadow-md">
+                <DonorList onSelect={setDonorId} />
+                <Autocomplete.Empty className="px-3 py-2 text-sm text-muted-foreground">
+                  {t('reports.noDonorsFound')}
+                </Autocomplete.Empty>
+              </Autocomplete.Popup>
+            </Autocomplete.Positioner>
+          </Autocomplete.Portal>
+        </Autocomplete.Root>
         <DateRangePicker
           from={range.from}
           to={range.to}

--- a/src/features/reports/reports-page.tsx
+++ b/src/features/reports/reports-page.tsx
@@ -1,6 +1,7 @@
 import { Autocomplete } from '@base-ui/react'
 import type { DonorResponse } from '@jorgetroya80/donations-api-client'
 import dayjs from 'dayjs'
+import { CircleX } from 'lucide-react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { DateRangePicker } from '@/components/date-range-picker'
@@ -207,17 +208,19 @@ function DonorStatementTab() {
             if (!v) setDonorId(null)
           }}
         >
-          <Autocomplete.InputGroup className="relative">
+          <Autocomplete.InputGroup className="grid items-center">
             <Autocomplete.Input
               placeholder={t('reports.searchDonor')}
               aria-label={t('reports.searchDonor')}
-              className="rounded-md border border-input bg-background px-3 py-2 pr-8 text-sm"
+              className="[grid-area:1/1] rounded-lg border border-input bg-background px-3 py-1.5 pr-8 text-sm"
             />
-            <Autocomplete.Clear className="absolute right-2 top-1/2 -translate-y-1/2 cursor-pointer text-muted-foreground transition-colors hover:text-foreground" />
+            <Autocomplete.Clear className="[grid-area:1/1] mr-3 cursor-pointer justify-self-end text-muted-foreground transition-colors hover:text-foreground">
+              <CircleX size={15} />
+            </Autocomplete.Clear>
           </Autocomplete.InputGroup>
           <Autocomplete.Portal>
             <Autocomplete.Positioner>
-              <Autocomplete.Popup className="z-50 min-w-(--anchor-width) rounded-md border border-input bg-background shadow-md">
+              <Autocomplete.Popup className="z-50 min-w-(--anchor-width) rounded-lg border border-input bg-background shadow-md mt-1">
                 <DonorList onSelect={setDonorId} />
                 <Autocomplete.Empty className="px-3 py-2 text-sm text-muted-foreground">
                   {t('reports.noDonorsFound')}

--- a/src/features/reports/reports-page.tsx
+++ b/src/features/reports/reports-page.tsx
@@ -176,7 +176,7 @@ function DonorList({ onSelect }: { onSelect: (id: number | null) => void }) {
           value={donor}
           index={i}
           onClick={() => onSelect(donor.id ?? null)}
-          className="cursor-pointer px-3 py-2 text-sm data-[highlighted]:bg-accent"
+          className="cursor-pointer px-3 py-2 text-sm data-highlighted:bg-accent"
         >
           {donor.fullName} — {donor.nationalId}
         </Autocomplete.Item>
@@ -202,7 +202,7 @@ function DonorStatementTab() {
       <div className="flex flex-wrap items-center gap-4">
         <Autocomplete.Root
           items={donors}
-          itemToStringValue={(d: DonorResponse) => d.fullName ?? ''}
+          itemToStringValue={(d) => d.fullName ?? ''}
           onValueChange={(v) => {
             if (!v) setDonorId(null)
           }}
@@ -213,6 +213,7 @@ function DonorStatementTab() {
               aria-label={t('reports.searchDonor')}
               className="rounded-md border border-input bg-background px-3 py-2 text-sm"
             />
+            <Autocomplete.Clear />
           </Autocomplete.InputGroup>
           <Autocomplete.Portal>
             <Autocomplete.Positioner>

--- a/src/features/reports/reports-page.tsx
+++ b/src/features/reports/reports-page.tsx
@@ -207,17 +207,17 @@ function DonorStatementTab() {
             if (!v) setDonorId(null)
           }}
         >
-          <Autocomplete.InputGroup>
+          <Autocomplete.InputGroup className="relative">
             <Autocomplete.Input
               placeholder={t('reports.searchDonor')}
               aria-label={t('reports.searchDonor')}
-              className="rounded-md border border-input bg-background px-3 py-2 text-sm"
+              className="rounded-md border border-input bg-background px-3 py-2 pr-8 text-sm"
             />
-            <Autocomplete.Clear />
+            <Autocomplete.Clear className="absolute right-2 top-1/2 -translate-y-1/2 cursor-pointer text-muted-foreground transition-colors hover:text-foreground" />
           </Autocomplete.InputGroup>
           <Autocomplete.Portal>
             <Autocomplete.Positioner>
-              <Autocomplete.Popup className="z-50 min-w-48 rounded-md border border-input bg-background shadow-md">
+              <Autocomplete.Popup className="z-50 min-w-(--anchor-width) rounded-md border border-input bg-background shadow-md">
                 <DonorList onSelect={setDonorId} />
                 <Autocomplete.Empty className="px-3 py-2 text-sm text-muted-foreground">
                   {t('reports.noDonorsFound')}

--- a/src/features/reports/reports-page.tsx
+++ b/src/features/reports/reports-page.tsx
@@ -166,7 +166,7 @@ function ExpenseSummaryTab() {
   )
 }
 
-function DonorList({ onSelect }: { onSelect: (id: number) => void }) {
+function DonorList({ onSelect }: { onSelect: (id: number | null) => void }) {
   const filtered = Autocomplete.useFilteredItems<DonorResponse>()
   return (
     <Autocomplete.List>
@@ -175,7 +175,7 @@ function DonorList({ onSelect }: { onSelect: (id: number) => void }) {
           key={donor.id}
           value={donor}
           index={i}
-          onClick={() => onSelect(donor.id ?? 0)}
+          onClick={() => onSelect(donor.id ?? null)}
           className="cursor-pointer px-3 py-2 text-sm data-[highlighted]:bg-accent"
         >
           {donor.fullName} — {donor.nationalId}
@@ -210,6 +210,7 @@ function DonorStatementTab() {
           <Autocomplete.InputGroup>
             <Autocomplete.Input
               placeholder={t('reports.searchDonor')}
+              aria-label={t('reports.searchDonor')}
               className="rounded-md border border-input bg-background px-3 py-2 text-sm"
             />
           </Autocomplete.InputGroup>

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -189,7 +189,6 @@
     "amount": "Monto",
     "date": "Fecha",
     "paymentMethod": "Método de pago",
-    "selectDonor": "Seleccione un donante",
     "noData": "Sin datos para el período seleccionado",
     "errorLoading": "Error al cargar el reporte",
     "noDonorSelected": "Seleccione un donante para ver su estado de cuenta",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -192,7 +192,9 @@
     "selectDonor": "Seleccione un donante",
     "noData": "Sin datos para el período seleccionado",
     "errorLoading": "Error al cargar el reporte",
-    "noDonorSelected": "Seleccione un donante para ver su estado de cuenta"
+    "noDonorSelected": "Seleccione un donante para ver su estado de cuenta",
+    "searchDonor": "Buscar donante...",
+    "noDonorsFound": "No se encontraron donantes"
   },
   "settings": {
     "changePassword": "Cambiar contraseña",


### PR DESCRIPTION
## Summary

- Replaces the plain `<select>` in `DonorStatementTab` with `@base-ui/react` `Autocomplete` — type-to-filter, keyboard-navigable, accessible
- Filtering is case-insensitive substring match on `fullName` (handled by Base-UI internally)
- Clear button overlaid inside input via CSS Grid area overlap (`[grid-area:1/1]`); no `position: absolute`
- Popup width matches input via `min-w-(--anchor-width)` (Base-UI CSS variable, Tailwind v4 utility)
- `donorId` safely falls back to `null` (not `0`) when no donor selected — prevents accidental statement load
- Added `aria-label` to autocomplete input for screen-reader accessibility
- Added i18n keys: `reports.searchDonor`, `reports.noDonorsFound`; removed orphaned `reports.selectDonor`


### Related

- Closes #122

## Test plan

- [ ] Navigate to Reports → Donor Statement
- [ ] Type partial donor name → filtered list appears
- [ ] Select donor → statement loads with date range
- [ ] Press × (clear) → input clears, statement hides, prompt message returns
- [ ] Type non-matching string → "No se encontraron donantes" appears
- [ ] Keyboard: `↑`/`↓` navigate, `Enter` selects, `Escape` closes
- [ ] `pnpm run check` passes
- [ ] `pnpm run test` passes (282 tests)

