### PR TITLE
feat: migrate to nested page paginated response shape

### DIFF
--- a/docs/plans/paginated-response-nested-page.md
+++ b/docs/plans/paginated-response-nested-page.md
@@ -1,0 +1,56 @@
+# Plan: Migrate to nested `page` paginated response shape
+
+## Context
+
+API ([issue #134](https://github.com/jorgetroya80/donations-frontend/issues/134), upstream [donations-api#33](https://github.com/jorgetroya80/donations-api/issues/33)) adopts Spring Data stable page serialization (`VIA_DTO`). Breaking change: pagination metadata moves from the response root into a nested `page` object.
+
+**Before:** `{ content, totalElements, totalPages, number, size, pageable, sort, first, last, numberOfElements, empty }`
+**After:** `{ content, page: { size, number, totalElements, totalPages } }`
+
+Removed root fields: `totalElements, totalPages, number, size, pageable, sort, first, last, numberOfElements, empty`. `content` unchanged.
+
+Frontend currently reads `data.number`, `data.totalPages`, `data.totalElements` directly off paged responses. Removed fields `first/last/numberOfElements/empty/pageable/sort` are **not used anywhere** — no derivation needed. Migration is mechanical: prefix metadata reads with `.page` and re-nest test mocks.
+
+## Prerequisite (do first, out of scope for code changes)
+
+Upgrade `@jorgetroya80/donations-api-client` from `1.7.1` to the new **major** version once published. Regenerated types: `PagedModel*Response { content, page: PageMetadata }`; old `Page*Response`, `PageableObject`, `SortObject` gone. `package.json:31`.
+
+> Status (2026-06-13): new major **not yet published**. This plan is written ahead; run the upgrade first, then apply code/test changes below.
+
+## Files to change
+
+### 1. Metadata reads (production code)
+
+Pattern: `data.<field>` → `data.page?.<field>`, keeping existing `?? 0` fallbacks.
+
+- [src/features/donations/donations-page.tsx:174-190](../../src/features/donations/donations-page.tsx) — `data.number` (x3), `data.totalPages` (x2) → `data.page?.number`, `data.page?.totalPages`
+- [src/features/donors/donors-page.tsx:136-152](../../src/features/donors/donors-page.tsx) — same pattern
+- [src/features/expenses/expenses-page.tsx:174-190](../../src/features/expenses/expenses-page.tsx) — same pattern
+- [src/features/users/users-page.tsx:147-163](../../src/features/users/users-page.tsx) — same pattern
+- [src/features/dashboard/use-user-stats.ts:15](../../src/features/dashboard/use-user-stats.ts) — `data.totalElements` → `data.page?.totalElements` (keep `totalUsers` shape)
+
+No changes in `use-donations.ts` / `use-donors.ts` / `use-expenses.ts` / `use-users.ts` — they return `data` untouched. Request-side `pageableQuerySerializer` ([src/lib/api.ts:71-87](../../src/lib/api.ts)) is unaffected (query params, not response).
+
+### 2. Test mocks (re-nest metadata under `page`)
+
+Replace root `totalElements/totalPages/size/number` with `page: { size, number, totalElements, totalPages }`.
+
+- [src/test/msw-handlers.ts](../../src/test/msw-handlers.ts) — 4 handlers: donations (~146-150), donors (~247-251), expenses (~328-332), users (~404-408)
+- [src/features/donations/use-donations.test.tsx](../../src/features/donations/use-donations.test.tsx) — mock ~101-108; assertion ~33
+- [src/features/donors/use-donors.test.tsx](../../src/features/donors/use-donors.test.tsx) — mock ~91-98; assertion ~33
+- [src/features/expenses/use-expenses.test.tsx](../../src/features/expenses/use-expenses.test.tsx) — mock ~103-110; assertion ~33
+- [src/features/users/use-users.test.tsx](../../src/features/users/use-users.test.tsx) — mock ~95-104; assertion ~28
+
+Test assertions reading `result.current.data.totalElements` → `result.current.data.page.totalElements`.
+
+## Verification
+
+1. `pnpm run build` — TypeScript compiles against new types (catches any missed `.page` prefix; old root fields no longer exist on type).
+2. `pnpm run test` — all hook/page tests green with re-nested mocks.
+3. `pnpm run check` — Biome clean.
+4. Manual (against new API): load donations, donors, expenses, users list views; click prev/next; confirm page counter (`page X / total`) correct and buttons disable at bounds. Confirm dashboard user-stats `totalUsers` correct.
+
+## Notes
+
+- Use optional chaining `data.page?.field ?? 0` to stay null-safe (matches current `?? 0` usage).
+- If new `PageMetadata` types are non-optional, `?.` is harmless; keep fallbacks for empty-state safety.

--- a/package.json
+++ b/package.json
@@ -17,18 +17,14 @@
     "typecheck": "tsc --noEmit -p tsconfig.app.json"
   },
   "lint-staged": {
-    "**/*.{cjs,css,js,json,mjs}": [
-      "biome format --write --staged"
-    ],
-    "src/**/*.{ts,tsx}": [
-      "biome lint --write --staged"
-    ]
+    "**/*.{cjs,css,js,json,mjs}": ["biome format --write --staged"],
+    "src/**/*.{ts,tsx}": ["biome lint --write --staged"]
   },
   "dependencies": {
     "@base-ui/react": "1.4.1",
     "@fontsource-variable/geist": "5.2.8",
     "@hookform/resolvers": "5.2.2",
-    "@jorgetroya80/donations-api-client": "1.7.1",
+    "@jorgetroya80/donations-api-client": "1.8.0",
     "@tanstack/react-query": "5.99.2",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: 5.2.2
         version: 5.2.2(react-hook-form@7.73.1(react@19.2.5))
       '@jorgetroya80/donations-api-client':
-        specifier: 1.7.1
-        version: 1.7.1
+        specifier: 1.8.0
+        version: 1.8.0
       '@tanstack/react-query':
         specifier: 5.99.2
         version: 5.99.2(react@19.2.5)
@@ -452,8 +452,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@jorgetroya80/donations-api-client@1.7.1':
-    resolution: {integrity: sha512-OOpAV4UQgy41PTZy5N1mwnLrlsETo07ohjq55y8iyFoR0WEoMy5p3B5N2Ah2q4LlpUfayD1Dar2TB/1on0ZCIg==, tarball: https://npm.pkg.github.com/download/@jorgetroya80/donations-api-client/1.7.1/53140cd39645c8cbc80f1fd065fd32e059c6360a}
+  '@jorgetroya80/donations-api-client@1.8.0':
+    resolution: {integrity: sha512-lFETC5gsBL5bppOTGHE1TfnPTZdXbOwZoDa4vjqbnYLD5KnuejrRVMXwrigpI9sF2PwJ6Us1DTNZ77roSP5Rtw==, tarball: https://npm.pkg.github.com/download/@jorgetroya80/donations-api-client/1.8.0/a7fdca85417b55e88889bfc410a5b9d2629a7ba2}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -2264,7 +2264,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.12.2
 
-  '@jorgetroya80/donations-api-client@1.7.1': {}
+  '@jorgetroya80/donations-api-client@1.8.0': {}
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:

--- a/src/features/dashboard/use-user-stats.ts
+++ b/src/features/dashboard/use-user-stats.ts
@@ -12,7 +12,7 @@ export function useUserStats() {
         throwOnError: true,
         querySerializer: pageableQuerySerializer,
       })
-      return { totalUsers: data.totalElements }
+      return { totalUsers: data.page?.totalElements }
     },
   })
 }

--- a/src/features/donations/donations-page.tsx
+++ b/src/features/donations/donations-page.tsx
@@ -171,15 +171,15 @@ export function DonationsPage() {
           <div className="flex items-center justify-between">
             <p className="text-sm text-muted-foreground">
               {t('donations.page', {
-                page: (data.number ?? 0) + 1,
-                total: data.totalPages ?? 0,
+                page: (data.page?.number ?? 0) + 1,
+                total: data.page?.totalPages ?? 0,
               })}
             </p>
             <div className="flex gap-2">
               <Button
                 variant="outline"
                 size="sm"
-                disabled={(data.number ?? 0) === 0}
+                disabled={(data.page?.number ?? 0) === 0}
                 onClick={() => setPage((p) => p - 1)}
               >
                 {t('donations.previous')}
@@ -187,7 +187,9 @@ export function DonationsPage() {
               <Button
                 variant="outline"
                 size="sm"
-                disabled={(data.number ?? 0) >= (data.totalPages ?? 0) - 1}
+                disabled={
+                  (data.page?.number ?? 0) >= (data.page?.totalPages ?? 0) - 1
+                }
                 onClick={() => setPage((p) => p + 1)}
               >
                 {t('donations.next')}

--- a/src/features/donations/use-donations.test.tsx
+++ b/src/features/donations/use-donations.test.tsx
@@ -30,7 +30,7 @@ describe('useDonations', () => {
     })
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
     expect(result.current.data?.content).toHaveLength(2)
-    expect(result.current.data?.totalElements).toBe(2)
+    expect(result.current.data?.page?.totalElements).toBe(2)
   })
 })
 
@@ -100,10 +100,12 @@ describe('useDonations - cancellation', () => {
         capturedSignal = request.signal
         return HttpResponse.json({
           content: [],
-          totalElements: 0,
-          totalPages: 0,
-          size: 10,
-          number: 0,
+          page: {
+            size: 10,
+            number: 0,
+            totalElements: 0,
+            totalPages: 0,
+          },
         })
       })
     )

--- a/src/features/donors/donors-page.tsx
+++ b/src/features/donors/donors-page.tsx
@@ -133,15 +133,15 @@ export function DonorsPage() {
           <div className="flex items-center justify-between">
             <p className="text-sm text-muted-foreground">
               {t('donors.page', {
-                page: (data.number ?? 0) + 1,
-                total: data.totalPages ?? 0,
+                page: (data.page?.number ?? 0) + 1,
+                total: data.page?.totalPages ?? 0,
               })}
             </p>
             <div className="flex gap-2">
               <Button
                 variant="outline"
                 size="sm"
-                disabled={(data.number ?? 0) === 0}
+                disabled={(data.page?.number ?? 0) === 0}
                 onClick={() => setPage((p) => p - 1)}
               >
                 {t('donors.previous')}
@@ -149,7 +149,9 @@ export function DonorsPage() {
               <Button
                 variant="outline"
                 size="sm"
-                disabled={(data.number ?? 0) >= (data.totalPages ?? 0) - 1}
+                disabled={
+                  (data.page?.number ?? 0) >= (data.page?.totalPages ?? 0) - 1
+                }
                 onClick={() => setPage((p) => p + 1)}
               >
                 {t('donors.next')}

--- a/src/features/donors/use-donors.test.tsx
+++ b/src/features/donors/use-donors.test.tsx
@@ -30,7 +30,7 @@ describe('useDonors', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
     expect(result.current.data?.content).toHaveLength(2)
     expect(result.current.data?.content?.[0].fullName).toBe('Juan Pérez')
-    expect(result.current.data?.totalElements).toBe(2)
+    expect(result.current.data?.page?.totalElements).toBe(2)
   })
 })
 
@@ -90,10 +90,12 @@ describe('useDonors - cancellation', () => {
         capturedSignal = request.signal
         return HttpResponse.json({
           content: [],
-          totalElements: 0,
-          totalPages: 0,
-          size: 10,
-          number: 0,
+          page: {
+            size: 10,
+            number: 0,
+            totalElements: 0,
+            totalPages: 0,
+          },
         })
       })
     )

--- a/src/features/expenses/expenses-page.tsx
+++ b/src/features/expenses/expenses-page.tsx
@@ -171,15 +171,15 @@ export function ExpensesPage() {
           <div className="flex items-center justify-between">
             <p className="text-sm text-muted-foreground">
               {t('expenses.page', {
-                page: (data.number ?? 0) + 1,
-                total: data.totalPages ?? 0,
+                page: (data.page?.number ?? 0) + 1,
+                total: data.page?.totalPages ?? 0,
               })}
             </p>
             <div className="flex gap-2">
               <Button
                 variant="outline"
                 size="sm"
-                disabled={(data.number ?? 0) === 0}
+                disabled={(data.page?.number ?? 0) === 0}
                 onClick={() => setPage((p) => p - 1)}
               >
                 {t('expenses.previous')}
@@ -187,7 +187,9 @@ export function ExpensesPage() {
               <Button
                 variant="outline"
                 size="sm"
-                disabled={(data.number ?? 0) >= (data.totalPages ?? 0) - 1}
+                disabled={
+                  (data.page?.number ?? 0) >= (data.page?.totalPages ?? 0) - 1
+                }
                 onClick={() => setPage((p) => p + 1)}
               >
                 {t('expenses.next')}

--- a/src/features/expenses/use-expenses.test.tsx
+++ b/src/features/expenses/use-expenses.test.tsx
@@ -30,7 +30,7 @@ describe('useExpenses', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
     expect(result.current.data?.content).toHaveLength(2)
     expect(result.current.data?.content?.[0].category).toBe('RENT')
-    expect(result.current.data?.totalElements).toBe(2)
+    expect(result.current.data?.page?.totalElements).toBe(2)
   })
 })
 
@@ -103,10 +103,12 @@ describe('useExpenses - cancellation', () => {
         capturedSignal = request.signal
         return HttpResponse.json({
           content: [],
-          totalElements: 0,
-          totalPages: 0,
-          size: 10,
-          number: 0,
+          page: {
+            size: 10,
+            number: 0,
+            totalElements: 0,
+            totalPages: 0,
+          },
         })
       })
     )

--- a/src/features/users/use-users.test.tsx
+++ b/src/features/users/use-users.test.tsx
@@ -25,7 +25,7 @@ describe('useUsers', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
     expect(result.current.data?.content).toHaveLength(2)
     expect(result.current.data?.content?.[0].username).toBe('admin')
-    expect(result.current.data?.totalElements).toBe(2)
+    expect(result.current.data?.page?.totalElements).toBe(2)
   })
 })
 
@@ -96,10 +96,12 @@ describe('useUsers - cancellation', () => {
         capturedSignal = request.signal
         return HttpResponse.json({
           content: [],
-          totalElements: 0,
-          totalPages: 0,
-          size: 10,
-          number: 0,
+          page: {
+            size: 10,
+            number: 0,
+            totalElements: 0,
+            totalPages: 0,
+          },
         })
       })
     )

--- a/src/features/users/users-page.tsx
+++ b/src/features/users/users-page.tsx
@@ -144,15 +144,15 @@ export function UsersPage() {
           <div className="flex items-center justify-between">
             <p className="text-sm text-muted-foreground">
               {t('users.page', {
-                page: (data.number ?? 0) + 1,
-                total: data.totalPages ?? 0,
+                page: (data.page?.number ?? 0) + 1,
+                total: data.page?.totalPages ?? 0,
               })}
             </p>
             <div className="flex gap-2">
               <Button
                 variant="outline"
                 size="sm"
-                disabled={(data.number ?? 0) === 0}
+                disabled={(data.page?.number ?? 0) === 0}
                 onClick={() => setPage((p) => p - 1)}
               >
                 {t('users.previous')}
@@ -160,7 +160,9 @@ export function UsersPage() {
               <Button
                 variant="outline"
                 size="sm"
-                disabled={(data.number ?? 0) >= (data.totalPages ?? 0) - 1}
+                disabled={
+                  (data.page?.number ?? 0) >= (data.page?.totalPages ?? 0) - 1
+                }
                 onClick={() => setPage((p) => p + 1)}
               >
                 {t('users.next')}

--- a/src/test/msw-handlers.ts
+++ b/src/test/msw-handlers.ts
@@ -143,10 +143,12 @@ export const handlers = [
           updatedAt: '2026-04-16T10:00:00',
         },
       ],
-      totalElements: 2,
-      totalPages: 1,
-      size: 10,
-      number: 0,
+      page: {
+        size: 10,
+        number: 0,
+        totalElements: 2,
+        totalPages: 1,
+      },
     })
   }),
 
@@ -244,10 +246,12 @@ export const handlers = [
           updatedAt: '2026-02-01T10:00:00',
         },
       ],
-      totalElements: 2,
-      totalPages: 1,
-      size: 10,
-      number: 0,
+      page: {
+        size: 10,
+        number: 0,
+        totalElements: 2,
+        totalPages: 1,
+      },
     })
   }),
 
@@ -325,10 +329,12 @@ export const handlers = [
           updatedAt: '2026-04-12T10:00:00',
         },
       ],
-      totalElements: 2,
-      totalPages: 1,
-      size: 10,
-      number: 0,
+      page: {
+        size: 10,
+        number: 0,
+        totalElements: 2,
+        totalPages: 1,
+      },
     })
   }),
 
@@ -401,10 +407,12 @@ export const handlers = [
           updatedAt: '2026-02-01T10:00:00',
         },
       ],
-      totalElements: 2,
-      totalPages: 1,
-      size: 10,
-      number: 0,
+      page: {
+        size: 10,
+        number: 0,
+        totalElements: 2,
+        totalPages: 1,
+      },
     })
   }),
 


### PR DESCRIPTION
## Context

API adopts Spring Data stable page serialization (`@EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO)`, upstream jorgetroya80/donations-api#33). Breaking change: pagination metadata moves from the response root into a nested `page` object.

**Before:** `{ content, totalElements, totalPages, number, size, pageable, sort, ... }`
**After:** `{ content, page: { size, number, totalElements, totalPages } }`

## Changes

- Bump `@jorgetroya80/donations-api-client` `1.7.1` → `1.8.0` (`PagedModel*Response { content, page: PageMetadata }`; old `Page*Response`/`PageableObject`/`SortObject` removed)
- Read metadata via `data.page?.{number,totalPages,totalElements}` (null-safe, fallbacks kept) across donations / donors / expenses / users pages + dashboard user-stats
- Re-nest pagination metadata under `page` in MSW handlers and hook tests

Removed fields (`first`/`last`/`numberOfElements`/`empty`/`pageable`/`sort`) were unused — no derivation needed.

## Related

- Closes #134

