### PR TITLE
feat(donors): server-side searchable donor picker (combobox)

### DIFF
--- a/docs/plans/donor-picker-search-combobox.md
+++ b/docs/plans/donor-picker-search-combobox.md
@@ -1,0 +1,84 @@
+# Plan: Server-side searchable DonorPicker (combobox)
+
+## Context
+
+Backend issue [donations-api#37](https://github.com/jorgetroya80/donations-api/issues/37) shipped: `GET /api/v1/donors` now accepts an optional `search` query param (case-insensitive partial match over `fullName` + `nationalId`, combines with `page`/`size`/`sort`, response shape unchanged).
+
+This is the **frontend follow-up**. Today [`donor-picker.tsx`](../../src/features/donors/donor-picker.tsx) is a Dialog + paginated Table: to find one donor the user pages 10 at a time. We replace it with a **debounced server-side typeahead combobox** built from plain HTML + Tailwind (no base-ui — per project convention; the reports-page Autocomplete does *client-side* filtering and is explicitly the wrong pattern here).
+
+Public component API stays identical (`{ value: number | null; onChange }`), so the consumer [`donation-form.tsx:198`](../../src/features/donations/donation-form.tsx) needs no change. The trigger keeps `id="donorId"` for the existing `<Label htmlFor="donorId">` association.
+
+## Prerequisite (confirmed by user)
+
+A new `@jorgetroya80/donations-api-client` version with `search` is published. Installed **1.8.0** types `ListDonorsData.query` as `{ pageable: Pageable }` only — no `search`. The bump is task 0 and gates everything (TS won't accept `search` until then).
+
+## Dependency graph
+
+```
+T0 bump client ─┬─> T1 data layer (useDonors.search + serializer + msw)
+                │        │
+                │        v
+                ├─> T2 useDebouncedValue hook
+                │        │
+                │        v
+                └─> T3 combobox DonorPicker (consumes T1 + T2)
+                          │
+                          v
+                      T4 i18n + a11y + tests + verify
+```
+
+## Vertical slices
+
+### T0 — Bump api-client (prerequisite checkpoint)
+- `package.json`: bump `@jorgetroya80/donations-api-client` from `1.8.0` to the published version containing `search` (confirm exact number at install).
+- `pnpm install`.
+- **Verify:** grep that `node_modules/@jorgetroya80/donations-api-client/dist/generated/types.gen.d.ts` `ListDonorsData.query` now includes `search?`. `pnpm typecheck` green.
+- 🚧 **CHECKPOINT** — do not proceed if the param isn't present in the regenerated types.
+
+### T1 — Data layer: thread `search` end-to-end
+One complete path: caller passes `search` → request carries `search=` → backend (mock) filters.
+- `src/features/donors/use-donors.ts`: add optional `search?: string` to `DonorListParams`; include in `queryKey`; pass `query.search` to `listDonors` (type-safe after T0). Omit when empty.
+- `src/lib/api.ts` `pageableQuerySerializer`: append `search=${encodeURIComponent(search)}` when present (mirrors existing `from`/`to` handling).
+- `src/test/msw-handlers.ts` `GET /donors`: read `url.searchParams.get('search')` and filter `content` case-insensitively over `fullName`/`nationalId` so tests exercise real server-side behavior.
+- **Acceptance:** new `useDonors` test asserts a `search` request hits the network with the param and returns the filtered subset.
+- **Verify:** `pnpm test src/features/donors/use-donors.test.tsx`, `pnpm typecheck`.
+
+### T2 — Debounce hook
+- New `src/lib/use-debounced-value.ts`: `useDebouncedValue<T>(value, delayMs)` — `setTimeout`, cleared on change/unmount. Small, single-purpose (none exists today).
+- **Acceptance:** unit test — value updates only after `delayMs` (fake timers).
+- **Verify:** `pnpm test src/lib/use-debounced-value.test.ts`.
+
+### T3 — Combobox DonorPicker (replaces dialog internals)
+Rewrite `donor-picker.tsx` internals; keep the exported `DonorPicker(props)` signature.
+- Plain `<input role="combobox">` with `id="donorId"`, `aria-autocomplete="list"`, `aria-expanded`, `aria-controls`, `aria-activedescendant`.
+- Local `inputValue` → `useDebouncedValue(inputValue, ~250ms)` → `useDonors({ page: 0, size: 10, search: debounced, sort: 'fullName,asc' })`.
+- Dropdown `role="listbox"`; each donor `role="option"` showing `fullName` + muted `nationalId`. Keyboard: ArrowDown/Up move highlight, Enter selects, Escape/Tab/blur close. Click selects.
+- Selected state: when `value` is set, show its name in the closed input. Keep `useDonor(value)` to resolve the label when the selected donor isn't in the current result set (e.g. editing an existing donation).
+- Clear (X) button → `onChange(null)`, clears input. Reuse existing `Button`/`Skeleton`/`Alert` where they fit; drop the now-unused `Dialog`/`Table`/`useSort` imports.
+- States: loading (skeleton rows), error (`donors.errorLoading`), empty (`noDonorsFound`).
+- **Acceptance:** typing filters via server, selecting calls `onChange(id)` and closes, clear resets, keyboard nav works, selected label renders for a preset `value`.
+
+### T4 — i18n, a11y, integration & full verify (checkpoint)
+- `src/locales/es.json`: add under `donations`: `searchDonor` ("Buscar donante…"), `noDonorsFound` ("No se encontraron donantes"). Keep `selectDonor`/`clearDonor`. (`reports.searchDonor`/`reports.noDonorsFound` already exist — mirror wording, don't share across namespaces.)
+- Rewrite `donor-picker.test.tsx` for combobox semantics (old `aria-haspopup="dialog"` assertions no longer apply).
+- Confirm `donation-form` / donation create+edit page tests still pass (component API unchanged).
+- **Verify (full suite):** `pnpm typecheck` && `pnpm test` && `pnpm check`. Then `pnpm dev` and manually: open a donation form, type in the donor field, confirm debounced results, select, clear, and edit-an-existing-donation preselect. 🚧 **CHECKPOINT** before commit.
+
+## Files touched
+- `package.json` (T0)
+- `src/features/donors/use-donors.ts`, `src/lib/api.ts`, `src/test/msw-handlers.ts` (T1)
+- `src/lib/use-debounced-value.ts` (+ test) (T2)
+- `src/features/donors/donor-picker.tsx` (T3)
+- `src/locales/es.json`, `src/features/donors/donor-picker.test.tsx`, `src/features/donors/use-donors.test.tsx` (T1/T4)
+
+## Out of scope
+- Reports-page donor Autocomplete (separate client-side component, issue #122).
+- Backend changes (already shipped).
+
+## Task list
+
+- [ ] **T0** Bump `@jorgetroya80/donations-api-client` to the `search`-capable version; `pnpm install`; verify regenerated types expose `search?`; `pnpm typecheck`. 🚧 checkpoint.
+- [ ] **T1** Add `search` to `useDonors` params + queryKey + `listDonors` query; extend `pageableQuerySerializer`; make msw `/donors` honor `search`; test param round-trip.
+- [ ] **T2** Add `useDebouncedValue` hook + test.
+- [ ] **T3** Rewrite DonorPicker as plain-HTML combobox (debounced server search, keyboard nav, a11y, selected-label via `useDonor`), keeping `{ value, onChange }` API and `id="donorId"`.
+- [ ] **T4** Add `donations.searchDonor`/`donations.noDonorsFound`; rewrite picker tests; confirm donation-form tests pass; full `typecheck` + `test` + `check`; manual dev verify. 🚧 checkpoint.

--- a/package.json
+++ b/package.json
@@ -17,18 +17,14 @@
     "typecheck": "tsc --noEmit -p tsconfig.app.json"
   },
   "lint-staged": {
-    "**/*.{cjs,css,js,json,mjs}": [
-      "biome format --write --staged"
-    ],
-    "src/**/*.{ts,tsx}": [
-      "biome lint --write --staged"
-    ]
+    "**/*.{cjs,css,js,json,mjs}": ["biome format --write --staged"],
+    "src/**/*.{ts,tsx}": ["biome lint --write --staged"]
   },
   "dependencies": {
     "@base-ui/react": "1.4.1",
     "@fontsource-variable/geist": "5.2.8",
     "@hookform/resolvers": "5.2.2",
-    "@jorgetroya80/donations-api-client": "1.8.0",
+    "@jorgetroya80/donations-api-client": "1.10.0",
     "@tanstack/react-query": "5.99.2",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: 5.2.2
         version: 5.2.2(react-hook-form@7.73.1(react@19.2.5))
       '@jorgetroya80/donations-api-client':
-        specifier: 1.8.0
-        version: 1.8.0
+        specifier: 1.10.0
+        version: 1.10.0
       '@tanstack/react-query':
         specifier: 5.99.2
         version: 5.99.2(react@19.2.5)
@@ -465,8 +465,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@jorgetroya80/donations-api-client@1.8.0':
-    resolution: {integrity: sha512-lFETC5gsBL5bppOTGHE1TfnPTZdXbOwZoDa4vjqbnYLD5KnuejrRVMXwrigpI9sF2PwJ6Us1DTNZ77roSP5Rtw==, tarball: https://npm.pkg.github.com/download/@jorgetroya80/donations-api-client/1.8.0/a7fdca85417b55e88889bfc410a5b9d2629a7ba2}
+  '@jorgetroya80/donations-api-client@1.10.0':
+    resolution: {integrity: sha512-eUODxTSeOiZe+h0oM1IOygJgBKJk7aLcpU2JPCilM9SFYKbICzrph3JmpTsozNNsg9Gi9LmhgjOmSIbW0hcDrg==, tarball: https://npm.pkg.github.com/download/@jorgetroya80/donations-api-client/1.10.0/7a893096bd557d61521be732a57393dc5da0379f}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -2294,7 +2294,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.12.2
 
-  '@jorgetroya80/donations-api-client@1.8.0': {}
+  '@jorgetroya80/donations-api-client@1.10.0': {}
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:

--- a/src/features/donors/donor-picker.test.tsx
+++ b/src/features/donors/donor-picker.test.tsx
@@ -124,6 +124,27 @@ describe('DonorPicker', () => {
     ).toBeInTheDocument()
   })
 
+  it('does not fetch the donor list until the picker is opened', async () => {
+    let calls = 0
+    server.use(
+      http.get('*/api/v1/donors', () => {
+        calls += 1
+        return HttpResponse.json({
+          content: [],
+          page: { size: 10, number: 0, totalElements: 0, totalPages: 0 },
+        })
+      })
+    )
+    const user = userEvent.setup()
+    renderWithProviders(<DonorPicker value={null} onChange={vi.fn()} />)
+
+    await new Promise((r) => setTimeout(r, 50))
+    expect(calls).toBe(0)
+
+    await user.click(screen.getByRole('combobox'))
+    await waitFor(() => expect(calls).toBeGreaterThan(0))
+  })
+
   it('closes the listbox on Escape', async () => {
     const user = userEvent.setup()
     renderWithProviders(<DonorPicker value={null} onChange={vi.fn()} />)

--- a/src/features/donors/donor-picker.test.tsx
+++ b/src/features/donors/donor-picker.test.tsx
@@ -1,8 +1,6 @@
 import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { HttpResponse, http } from 'msw'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { server } from '@/test/msw-server'
 import { renderWithProviders } from '@/test/test-utils'
 import { DonorPicker } from './donor-picker'
 
@@ -14,138 +12,87 @@ beforeEach(() => {
 })
 
 describe('DonorPicker', () => {
-  it('shows placeholder when no value is selected', () => {
+  it('renders a combobox with a search placeholder when no value is selected', () => {
     renderWithProviders(<DonorPicker value={null} onChange={vi.fn()} />)
-    expect(
-      screen.getByRole('button', { name: 'Seleccione donante' })
-    ).toBeInTheDocument()
-  })
-
-  it('trigger exposes dialog popup semantics and toggles aria-expanded', async () => {
-    const user = userEvent.setup()
-    renderWithProviders(<DonorPicker value={null} onChange={vi.fn()} />)
-
-    const trigger = screen.getByRole('button', { name: 'Seleccione donante' })
-    expect(trigger).toHaveAttribute('id', 'donorId')
-    expect(trigger).toHaveAttribute('aria-haspopup', 'dialog')
-    expect(trigger).toHaveAttribute('aria-expanded', 'false')
-
-    await user.click(trigger)
-    await waitFor(() => {
-      expect(trigger).toHaveAttribute('aria-expanded', 'true')
-    })
+    const combobox = screen.getByRole('combobox')
+    expect(combobox).toHaveAttribute('id', 'donorId')
+    expect(combobox).toHaveAttribute('placeholder', 'Buscar donante…')
+    expect(combobox).toHaveAttribute('aria-expanded', 'false')
+    expect(combobox).toHaveValue('')
   })
 
   it('shows the selected donor name when a value is set', async () => {
     renderWithProviders(<DonorPicker value={1} onChange={vi.fn()} />)
-    await waitFor(() => {
-      expect(
-        screen.getByRole('button', { name: 'Juan Pérez' })
-      ).toBeInTheDocument()
-    })
+    await waitFor(() =>
+      expect(screen.getByRole('combobox')).toHaveValue('Juan Pérez')
+    )
   })
 
-  it('opens the dialog and renders donor rows', async () => {
+  it('opens the listbox on focus and lists donors', async () => {
     const user = userEvent.setup()
     renderWithProviders(<DonorPicker value={null} onChange={vi.fn()} />)
 
-    await user.click(screen.getByRole('button', { name: 'Seleccione donante' }))
-
-    await waitFor(() => {
-      expect(
-        screen.getByRole('button', { name: 'Juan Pérez' })
-      ).toBeInTheDocument()
-    })
+    await user.click(screen.getByRole('combobox'))
+    await waitFor(() =>
+      expect(screen.getByRole('combobox')).toHaveAttribute(
+        'aria-expanded',
+        'true'
+      )
+    )
     expect(
-      screen.getByRole('button', { name: 'María García' })
+      await screen.findByRole('option', { name: /Juan Pérez/ })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('option', { name: /María García/ })
     ).toBeInTheDocument()
   })
 
-  it('selecting a row calls onChange with the donor id and closes the dialog', async () => {
-    const user = userEvent.setup()
+  it('filters via server-side search and selects a donor', async () => {
     const onChange = vi.fn()
+    const user = userEvent.setup()
     renderWithProviders(<DonorPicker value={null} onChange={onChange} />)
 
-    await user.click(screen.getByRole('button', { name: 'Seleccione donante' }))
-    await waitFor(() => {
-      expect(
-        screen.getByRole('button', { name: 'Juan Pérez' })
-      ).toBeInTheDocument()
-    })
+    const combobox = screen.getByRole('combobox')
+    await user.click(combobox)
+    await user.type(combobox, 'maría')
 
-    await user.click(screen.getByRole('button', { name: 'Juan Pérez' }))
+    await waitFor(() =>
+      expect(screen.queryByRole('option', { name: /Juan Pérez/ })).toBeNull()
+    )
+    const option = await screen.findByRole('option', { name: /María García/ })
+    await user.click(option)
+
+    expect(onChange).toHaveBeenCalledWith(2)
+    await waitFor(() =>
+      expect(screen.getByRole('combobox')).toHaveAttribute(
+        'aria-expanded',
+        'false'
+      )
+    )
+  })
+
+  it('selects the highlighted donor with the keyboard', async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+    renderWithProviders(<DonorPicker value={null} onChange={onChange} />)
+
+    const combobox = screen.getByRole('combobox')
+    await user.click(combobox)
+    await screen.findByRole('option', { name: /Juan Pérez/ })
+    await user.keyboard('{ArrowDown}{Enter}')
 
     expect(onChange).toHaveBeenCalledWith(1)
-    await waitFor(() => {
-      expect(
-        screen.queryByRole('button', { name: 'María García' })
-      ).not.toBeInTheDocument()
-    })
   })
 
-  it('clear button resets the value to null', async () => {
-    const user = userEvent.setup()
+  it('clears the selection', async () => {
     const onChange = vi.fn()
+    const user = userEvent.setup()
     renderWithProviders(<DonorPicker value={1} onChange={onChange} />)
+    await waitFor(() =>
+      expect(screen.getByRole('combobox')).toHaveValue('Juan Pérez')
+    )
 
-    const clearButton = await screen.findByRole('button', {
-      name: 'Quitar donante',
-    })
-    await user.click(clearButton)
-
+    await user.click(screen.getByRole('button', { name: 'Quitar donante' }))
     expect(onChange).toHaveBeenCalledWith(null)
-  })
-
-  it('paginates to the next page', async () => {
-    const user = userEvent.setup()
-    server.use(
-      http.get('*/api/v1/donors', ({ request }) => {
-        const page = Number(new URL(request.url).searchParams.get('page') ?? 0)
-        const donor =
-          page === 0
-            ? { id: 1, fullName: 'Juan Pérez', nationalId: '12345678A' }
-            : { id: 2, fullName: 'Ana López', nationalId: '99999999Z' }
-        return HttpResponse.json({
-          content: [{ ...donor, active: true }],
-          page: { size: 1, number: page, totalElements: 2, totalPages: 2 },
-        })
-      })
-    )
-
-    renderWithProviders(<DonorPicker value={null} onChange={vi.fn()} />)
-    await user.click(screen.getByRole('button', { name: 'Seleccione donante' }))
-
-    await waitFor(() => {
-      expect(
-        screen.getByRole('button', { name: 'Juan Pérez' })
-      ).toBeInTheDocument()
-    })
-
-    await user.click(screen.getByRole('button', { name: 'Siguiente' }))
-
-    await waitFor(() => {
-      expect(
-        screen.getByRole('button', { name: 'Ana López' })
-      ).toBeInTheDocument()
-    })
-  })
-
-  it('shows an error message when the donor request fails', async () => {
-    const user = userEvent.setup()
-    server.use(
-      http.get('*/api/v1/donors', () => new HttpResponse(null, { status: 500 }))
-    )
-
-    renderWithProviders(<DonorPicker value={null} onChange={vi.fn()} />)
-    await user.click(screen.getByRole('button', { name: 'Seleccione donante' }))
-
-    await waitFor(() => {
-      expect(
-        screen.getByText('Error al cargar los donantes')
-      ).toBeInTheDocument()
-    })
-    expect(
-      screen.queryByText('No hay donantes registrados')
-    ).not.toBeInTheDocument()
   })
 })

--- a/src/features/donors/donor-picker.test.tsx
+++ b/src/features/donors/donor-picker.test.tsx
@@ -1,6 +1,8 @@
 import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { HttpResponse, http } from 'msw'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { server } from '@/test/msw-server'
 import { renderWithProviders } from '@/test/test-utils'
 import { DonorPicker } from './donor-picker'
 
@@ -94,5 +96,46 @@ describe('DonorPicker', () => {
 
     await user.click(screen.getByRole('button', { name: 'Quitar donante' }))
     expect(onChange).toHaveBeenCalledWith(null)
+  })
+
+  it('shows an empty state when search yields no donors', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<DonorPicker value={null} onChange={vi.fn()} />)
+
+    const combobox = screen.getByRole('combobox')
+    await user.click(combobox)
+    await user.type(combobox, 'zzz')
+
+    expect(
+      await screen.findByText('No se encontraron donantes')
+    ).toBeInTheDocument()
+  })
+
+  it('surfaces an error when the donor request fails', async () => {
+    server.use(
+      http.get('*/api/v1/donors', () => new HttpResponse(null, { status: 500 }))
+    )
+    const user = userEvent.setup()
+    renderWithProviders(<DonorPicker value={null} onChange={vi.fn()} />)
+
+    await user.click(screen.getByRole('combobox'))
+    expect(
+      await screen.findByText('Error al cargar los donantes')
+    ).toBeInTheDocument()
+  })
+
+  it('closes the listbox on Escape', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<DonorPicker value={null} onChange={vi.fn()} />)
+
+    const combobox = screen.getByRole('combobox')
+    await user.click(combobox)
+    await screen.findByRole('option', { name: /Juan Pérez/ })
+
+    await user.keyboard('{Escape}')
+    await waitFor(() =>
+      expect(combobox).toHaveAttribute('aria-expanded', 'false')
+    )
+    expect(screen.queryByRole('listbox')).toBeNull()
   })
 })

--- a/src/features/donors/donor-picker.tsx
+++ b/src/features/donors/donor-picker.tsx
@@ -23,12 +23,10 @@ export function DonorPicker({ value, onChange }: DonorPickerProps) {
   const debouncedQuery = useDebouncedValue(query, 250)
 
   const { data: selectedDonor } = useDonor(value ?? 0)
-  const { data, isLoading, error } = useDonors({
-    page: 0,
-    size: 10,
-    sort: 'fullName,asc',
-    search: debouncedQuery,
-  })
+  const { data, isLoading, error } = useDonors(
+    { page: 0, size: 10, sort: 'fullName,asc', search: debouncedQuery },
+    { enabled: open }
+  )
   const donors = data?.content ?? []
 
   // Close on outside interaction.
@@ -94,7 +92,7 @@ export function DonorPicker({ value, onChange }: DonorPickerProps) {
           open && highlight >= 0 ? optionId(donors[highlight]?.id) : undefined
         }
         placeholder={t('donations.searchDonor')}
-        className="flex h-9 min-w-0 flex-1 rounded-md border border-input bg-background px-3 py-1 text-sm shadow-xs transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        className="flex h-8 min-w-0 flex-1 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base shadow-xs transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 md:text-sm"
         value={inputValue}
         onFocus={() => {
           if (!open) openWithFreshQuery()
@@ -126,7 +124,7 @@ export function DonorPicker({ value, onChange }: DonorPickerProps) {
       </Button>
 
       {open && (
-        <div className="absolute top-10 left-0 z-50 w-full overflow-hidden rounded-md border border-input bg-background shadow-md">
+        <div className="absolute top-9 left-0 z-50 w-full overflow-hidden rounded-lg border border-input bg-background shadow-md">
           {error ? (
             <Alert variant="destructive" className="border-0">
               <AlertDescription>{t('donors.errorLoading')}</AlertDescription>

--- a/src/features/donors/donor-picker.tsx
+++ b/src/features/donors/donor-picker.tsx
@@ -1,24 +1,10 @@
-import { ChevronsUpDown, X } from 'lucide-react'
-import { useState } from 'react'
+import { X } from 'lucide-react'
+import { useEffect, useId, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Skeleton } from '@/components/skeleton'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog'
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table'
-import { useSort } from '@/lib/use-sort'
+import { useDebouncedValue } from '@/lib/use-debounced-value'
 import { useDonor, useDonors } from './use-donors'
 
 interface DonorPickerProps {
@@ -28,30 +14,98 @@ interface DonorPickerProps {
 
 export function DonorPicker({ value, onChange }: DonorPickerProps) {
   const { t } = useTranslation()
-  const [open, setOpen] = useState(false)
-  const { data: selectedDonor } = useDonor(value ?? 0)
+  const listboxId = useId()
+  const containerRef = useRef<HTMLDivElement>(null)
 
-  const label =
-    value && selectedDonor?.fullName
-      ? selectedDonor.fullName
-      : t('donations.selectDonor')
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const [highlight, setHighlight] = useState(-1)
+  const debouncedQuery = useDebouncedValue(query, 250)
+
+  const { data: selectedDonor } = useDonor(value ?? 0)
+  const { data, isLoading, error } = useDonors({
+    page: 0,
+    size: 10,
+    sort: 'fullName,asc',
+    search: debouncedQuery,
+  })
+  const donors = data?.content ?? []
+
+  // Close on outside interaction.
+  useEffect(() => {
+    if (!open) return
+    function onPointerDown(e: PointerEvent) {
+      if (!containerRef.current?.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener('pointerdown', onPointerDown)
+    return () => document.removeEventListener('pointerdown', onPointerDown)
+  }, [open])
+
+  const optionId = (id: number | undefined) => `${listboxId}-opt-${id}`
+
+  function select(id: number | null | undefined) {
+    if (id == null) return
+    onChange(id)
+    setOpen(false)
+    setQuery('')
+    setHighlight(-1)
+  }
+
+  function openWithFreshQuery() {
+    setOpen(true)
+    setQuery('')
+    setHighlight(-1)
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      if (!open) {
+        openWithFreshQuery()
+        return
+      }
+      setHighlight((h) => Math.min(h + 1, donors.length - 1))
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      setHighlight((h) => Math.max(h - 1, 0))
+    } else if (e.key === 'Enter') {
+      if (highlight >= 0 && donors[highlight]) {
+        e.preventDefault()
+        select(donors[highlight].id)
+      }
+    } else if (e.key === 'Escape') {
+      setOpen(false)
+    }
+  }
+
+  const inputValue = open ? query : (selectedDonor?.fullName ?? '')
 
   return (
-    <div className="flex gap-2">
-      <Button
-        type="button"
+    <div ref={containerRef} className="relative flex gap-2">
+      <input
         id="donorId"
-        variant="outline"
-        aria-haspopup="dialog"
+        type="text"
+        role="combobox"
+        autoComplete="off"
+        aria-autocomplete="list"
         aria-expanded={open}
-        className="min-w-0 flex-1 justify-between font-normal"
-        onClick={() => setOpen(true)}
-      >
-        <span className={`truncate ${value ? '' : 'text-muted-foreground'}`}>
-          {label}
-        </span>
-        <ChevronsUpDown size={16} className="opacity-50" aria-hidden="true" />
-      </Button>
+        aria-controls={listboxId}
+        aria-activedescendant={
+          open && highlight >= 0 ? optionId(donors[highlight]?.id) : undefined
+        }
+        placeholder={t('donations.searchDonor')}
+        className="flex h-9 min-w-0 flex-1 rounded-md border border-input bg-background px-3 py-1 text-sm shadow-xs transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        value={inputValue}
+        onFocus={() => {
+          if (!open) openWithFreshQuery()
+        }}
+        onChange={(e) => {
+          setQuery(e.target.value)
+          setHighlight(-1)
+          if (!open) setOpen(true)
+        }}
+        onKeyDown={handleKeyDown}
+      />
       <Button
         type="button"
         variant="ghost"
@@ -62,153 +116,64 @@ export function DonorPicker({ value, onChange }: DonorPickerProps) {
         className={`transition-opacity duration-150 ${
           value == null ? 'pointer-events-none opacity-0' : 'opacity-100'
         }`}
-        onClick={() => onChange(null)}
+        onClick={() => {
+          onChange(null)
+          setQuery('')
+          setOpen(false)
+        }}
       >
         <X size={16} />
       </Button>
-      <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent className="sm:max-w-2xl">
-          <DialogHeader>
-            <DialogTitle>{t('donations.selectDonor')}</DialogTitle>
-          </DialogHeader>
-          <DonorPickerTable
-            selectedId={value}
-            onSelect={(id) => {
-              onChange(id)
-              setOpen(false)
-            }}
-          />
-        </DialogContent>
-      </Dialog>
-    </div>
-  )
-}
 
-function DonorPickerTable({
-  selectedId,
-  onSelect,
-}: {
-  selectedId: number | null
-  onSelect: (id: number) => void
-}) {
-  const { t } = useTranslation()
-  const [page, setPage] = useState(0)
-  const { sort, toggleSort, sortIndicator, ariaSort } = useSort(
-    'fullName,asc',
-    () => setPage(0)
-  )
-  const { data, isLoading, error } = useDonors({ page, size: 10, sort })
-  const donors = data?.content ?? []
-
-  if (isLoading) {
-    return (
-      <div
-        aria-busy="true"
-        aria-label={t('common.loading')}
-        className="space-y-2"
-      >
-        {Array.from({ length: 10 }, (_, i) => (
-          <Skeleton key={i} />
-        ))}
-      </div>
-    )
-  }
-
-  if (error) {
-    return (
-      <Alert variant="destructive">
-        <AlertDescription>{t('donors.errorLoading')}</AlertDescription>
-      </Alert>
-    )
-  }
-
-  if (donors.length === 0) {
-    return (
-      <p className="py-8 text-center text-muted-foreground">
-        {t('donors.empty')}
-      </p>
-    )
-  }
-
-  return (
-    <div className="space-y-4">
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead
-              className="cursor-pointer"
-              onClick={() => toggleSort('fullName')}
-              tabIndex={0}
-              aria-sort={ariaSort('fullName')}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  e.preventDefault()
-                  toggleSort('fullName')
-                }
-              }}
+      {open && (
+        <div className="absolute top-10 left-0 z-50 w-full overflow-hidden rounded-md border border-input bg-background shadow-md">
+          {error ? (
+            <Alert variant="destructive" className="border-0">
+              <AlertDescription>{t('donors.errorLoading')}</AlertDescription>
+            </Alert>
+          ) : isLoading ? (
+            <div
+              aria-busy="true"
+              aria-label={t('common.loading')}
+              className="space-y-2 p-2"
             >
-              {t('donors.fullName')}
-              <span aria-hidden="true">{sortIndicator('fullName')}</span>
-            </TableHead>
-            <TableHead>{t('donors.nationalId')}</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {donors.map((donor) => (
-            <TableRow
-              key={donor.id}
-              role="button"
-              tabIndex={0}
-              aria-label={donor.fullName}
-              data-state={donor.id === selectedId ? 'selected' : undefined}
-              className="cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
-              onClick={() => {
-                if (donor.id != null) onSelect(donor.id)
-              }}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  e.preventDefault()
-                  if (donor.id != null) onSelect(donor.id)
-                }
-              }}
+              {Array.from({ length: 5 }, (_, i) => (
+                <Skeleton key={i} />
+              ))}
+            </div>
+          ) : donors.length === 0 ? (
+            <p className="px-3 py-6 text-center text-sm text-muted-foreground">
+              {t('donations.noDonorsFound')}
+            </p>
+          ) : (
+            <ul
+              id={listboxId}
+              role="listbox"
+              className="max-h-64 overflow-auto py-1"
             >
-              <TableCell className="font-medium">{donor.fullName}</TableCell>
-              <TableCell>{donor.nationalId ?? '—'}</TableCell>
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
-
-      <div className="flex items-center justify-between">
-        <p className="text-sm text-muted-foreground">
-          {t('donors.page', {
-            page: (data?.page?.number ?? 0) + 1,
-            total: data?.page?.totalPages ?? 0,
-          })}
-        </p>
-        <div className="flex gap-2">
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            disabled={(data?.page?.number ?? 0) === 0}
-            onClick={() => setPage((p) => p - 1)}
-          >
-            {t('donors.previous')}
-          </Button>
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            disabled={
-              (data?.page?.number ?? 0) >= (data?.page?.totalPages ?? 0) - 1
-            }
-            onClick={() => setPage((p) => p + 1)}
-          >
-            {t('donors.next')}
-          </Button>
+              {donors.map((donor, i) => (
+                <li
+                  key={donor.id}
+                  id={optionId(donor.id)}
+                  role="option"
+                  aria-selected={i === highlight}
+                  className={`flex cursor-pointer flex-col px-3 py-2 text-sm ${
+                    i === highlight ? 'bg-accent' : ''
+                  } ${donor.id === value ? 'font-medium' : ''}`}
+                  onMouseDown={(e) => e.preventDefault()}
+                  onMouseEnter={() => setHighlight(i)}
+                  onClick={() => select(donor.id)}
+                >
+                  <span>{donor.fullName}</span>
+                  <span className="text-xs text-muted-foreground">
+                    {donor.nationalId ?? '—'}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
         </div>
-      </div>
+      )}
     </div>
   )
 }

--- a/src/features/donors/use-donors.test.tsx
+++ b/src/features/donors/use-donors.test.tsx
@@ -32,6 +32,16 @@ describe('useDonors', () => {
     expect(result.current.data?.content?.[0].fullName).toBe('Juan Pérez')
     expect(result.current.data?.page?.totalElements).toBe(2)
   })
+
+  it('forwards the search param and returns the filtered subset', async () => {
+    const { result } = renderHook(
+      () => useDonors({ page: 0, size: 10, search: 'maría' }),
+      { wrapper: createWrapper() }
+    )
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data?.content).toHaveLength(1)
+    expect(result.current.data?.content?.[0].fullName).toBe('María García')
+  })
 })
 
 describe('useDonor', () => {

--- a/src/features/donors/use-donors.ts
+++ b/src/features/donors/use-donors.ts
@@ -16,9 +16,13 @@ interface DonorListParams {
   search?: string
 }
 
-export function useDonors(params: DonorListParams) {
+export function useDonors(
+  params: DonorListParams,
+  options?: { enabled?: boolean }
+) {
   return useQuery({
     queryKey: ['donors', params],
+    enabled: options?.enabled,
     queryFn: ({ signal }) =>
       listDonors({
         query: {

--- a/src/features/donors/use-donors.ts
+++ b/src/features/donors/use-donors.ts
@@ -13,6 +13,7 @@ interface DonorListParams {
   page: number
   size: number
   sort?: string
+  search?: string
 }
 
 export function useDonors(params: DonorListParams) {
@@ -21,6 +22,7 @@ export function useDonors(params: DonorListParams) {
     queryFn: ({ signal }) =>
       listDonors({
         query: {
+          search: params.search || undefined,
           pageable: {
             page: params.page,
             size: params.size,

--- a/src/features/expenses/expense-schema.ts
+++ b/src/features/expenses/expense-schema.ts
@@ -7,6 +7,7 @@ export const expenseCategories = [
   'SUPPLIES',
   'MISSIONS',
   'MAINTENANCE',
+  'IRPF',
   'OTHER',
 ] as const
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -74,11 +74,13 @@ export function pageableQuerySerializer(q: unknown): string {
   const query = q as {
     from?: string
     to?: string
+    search?: string
     pageable?: { page?: number; size?: number; sort?: string[] }
   }
   const parts: string[] = []
   if (query.from) parts.push(`from=${query.from}`)
   if (query.to) parts.push(`to=${query.to}`)
+  if (query.search) parts.push(`search=${encodeURIComponent(query.search)}`)
   const { page, size, sort } = query.pageable ?? {}
   if (page !== undefined) parts.push(`page=${page}`)
   if (size !== undefined) parts.push(`size=${size}`)

--- a/src/lib/use-debounced-value.test.ts
+++ b/src/lib/use-debounced-value.test.ts
@@ -1,0 +1,45 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useDebouncedValue } from '@/lib/use-debounced-value'
+
+describe('useDebouncedValue', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  it('returns the initial value immediately', () => {
+    const { result } = renderHook(() => useDebouncedValue('a', 250))
+    expect(result.current).toBe('a')
+  })
+
+  it('updates only after the delay elapses', () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebouncedValue(value, 250),
+      { initialProps: { value: 'a' } }
+    )
+
+    rerender({ value: 'b' })
+    expect(result.current).toBe('a')
+
+    act(() => vi.advanceTimersByTime(249))
+    expect(result.current).toBe('a')
+
+    act(() => vi.advanceTimersByTime(1))
+    expect(result.current).toBe('b')
+  })
+
+  it('resets the timer on rapid changes (only the last value lands)', () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebouncedValue(value, 250),
+      { initialProps: { value: 'a' } }
+    )
+
+    rerender({ value: 'b' })
+    act(() => vi.advanceTimersByTime(200))
+    rerender({ value: 'c' })
+    act(() => vi.advanceTimersByTime(200))
+    expect(result.current).toBe('a')
+
+    act(() => vi.advanceTimersByTime(50))
+    expect(result.current).toBe('c')
+  })
+})

--- a/src/lib/use-debounced-value.ts
+++ b/src/lib/use-debounced-value.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from 'react'
+
+export function useDebouncedValue<T>(value: T, delayMs: number): T {
+  const [debounced, setDebounced] = useState(value)
+
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(value), delayMs)
+    return () => clearTimeout(id)
+  }, [value, delayMs])
+
+  return debounced
+}

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -129,6 +129,7 @@
       "SUPPLIES": "Suministros",
       "MISSIONS": "Misiones",
       "MAINTENANCE": "Mantenimiento",
+      "IRPF": "IRPF",
       "OTHER": "Otro"
     },
     "paymentMethods": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -82,6 +82,8 @@
     "selectPayment": "Seleccione método",
     "selectDonor": "Seleccione donante",
     "clearDonor": "Quitar donante",
+    "searchDonor": "Buscar donante…",
+    "noDonorsFound": "No se encontraron donantes",
     "editLabel": "Editar donación del {{date}}"
   },
   "donors": {

--- a/src/test/msw-handlers.ts
+++ b/src/test/msw-handlers.ts
@@ -245,7 +245,9 @@ export const handlers = [
         updatedAt: '2026-02-01T10:00:00',
       },
     ]
-    const search = new URL(request.url).searchParams.get('search')?.toLowerCase()
+    const search = new URL(request.url).searchParams
+      .get('search')
+      ?.toLowerCase()
     const content = search
       ? allDonors.filter(
           (d) =>

--- a/src/test/msw-handlers.ts
+++ b/src/test/msw-handlers.ts
@@ -220,37 +220,46 @@ export const handlers = [
     })
   }),
 
-  http.get(`${API}/donors`, () => {
+  http.get(`${API}/donors`, ({ request }) => {
+    const allDonors = [
+      {
+        id: 1,
+        fullName: 'Juan Pérez',
+        nationalId: '12345678A',
+        email: 'juan@test.com',
+        phone: null,
+        address: null,
+        active: true,
+        createdAt: '2026-01-01T10:00:00',
+        updatedAt: '2026-01-01T10:00:00',
+      },
+      {
+        id: 2,
+        fullName: 'María García',
+        nationalId: '87654321B',
+        email: null,
+        phone: '600123456',
+        address: 'Calle Mayor 1',
+        active: false,
+        createdAt: '2026-02-01T10:00:00',
+        updatedAt: '2026-02-01T10:00:00',
+      },
+    ]
+    const search = new URL(request.url).searchParams.get('search')?.toLowerCase()
+    const content = search
+      ? allDonors.filter(
+          (d) =>
+            d.fullName.toLowerCase().includes(search) ||
+            d.nationalId.toLowerCase().includes(search)
+        )
+      : allDonors
     return HttpResponse.json({
-      content: [
-        {
-          id: 1,
-          fullName: 'Juan Pérez',
-          nationalId: '12345678A',
-          email: 'juan@test.com',
-          phone: null,
-          address: null,
-          active: true,
-          createdAt: '2026-01-01T10:00:00',
-          updatedAt: '2026-01-01T10:00:00',
-        },
-        {
-          id: 2,
-          fullName: 'María García',
-          nationalId: '87654321B',
-          email: null,
-          phone: '600123456',
-          address: 'Calle Mayor 1',
-          active: false,
-          createdAt: '2026-02-01T10:00:00',
-          updatedAt: '2026-02-01T10:00:00',
-        },
-      ],
+      content,
       page: {
         size: 10,
         number: 0,
-        totalElements: 2,
-        totalPages: 1,
+        totalElements: content.length,
+        totalPages: content.length === 0 ? 0 : 1,
       },
     })
   }),


### PR DESCRIPTION
## Context

Frontend follow-up to [donations-api#37](https://github.com/jorgetroya80/donations-api/issues/37), which added an optional `search` query param to `GET /api/v1/donors` (case-insensitive partial match over `fullName` + `nationalId`, combines with `page`/`size`/`sort`).

The donor picker was a Dialog + paginated table — finding one donor meant paging 10 at a time. This replaces it with a **debounced server-side typeahead combobox**.

## Changes

- **`chore(deps)`** — bump `@jorgetroya80/donations-api-client` 1.8.0 → 1.10.0 (exposes `search`; also adds the `IRPF` expense category, wired into the expense schema + i18n).
- **`feat(donors)`** — thread `search` through `useDonors` → `listDonors` + `pageableQuerySerializer`; mock honors it.
- **`feat(lib)`** — `useDebouncedValue` hook.
- **`feat(donors)`** — rewrite `DonorPicker` as a plain HTML + Tailwind combobox: debounced server search, aria listbox with keyboard nav (↑/↓/Enter/Esc), outside-click + Escape close, selected label via `useDonor`. Public `{ value, onChange }` API unchanged → `donation-form` untouched.
- **`perf(donors)`** — gate the list query with `enabled: open` so `/donors` isn't fetched on every donation-form load; align input with shared `Input` tokens (h-8, rounded-lg, ring-3) and concentric popup radius.

## Testing

- Combobox covers: placeholder, selected label, open/list, server filter + select, keyboard select, clear, empty, error, Escape, and fetch-gating.


Out of scope: reports-page donor Autocomplete (separate client-side component, #122).

