### PR TITLE
feat(reports): use searchable DonorPicker in donor-statement tab

### DIFF
--- a/docs/PRD-donor-picker-reports.md
+++ b/docs/PRD-donor-picker-reports.md
@@ -1,0 +1,92 @@
+# Spec: Use DonorPicker in Reports donor-statement tab
+
+## Objective
+
+Replace the hand-rolled base-ui `Autocomplete` in the donor-statement tab of
+[reports-page.tsx](../src/features/reports/reports-page.tsx) with the existing server-side
+searchable [DonorPicker](../src/features/donors/donor-picker.tsx) component.
+
+**Target users:** report viewers selecting a donor to generate a statement.
+
+**Problem:** the current picker uses client-side `useDonors()` from
+[use-donations.ts](../src/features/donations/use-donations.ts), which hard-fetches the first 100
+donors and filters in-browser — cannot scale past 100, and duplicates picker UI that already
+exists. DonorPicker debounces a `search` term into the search-capable `useDonors()` in
+[use-donors.ts](../src/features/donors/use-donors.ts) (backend search-by-term endpoint).
+
+**Outcome:** donor search hits the backend by term (no 100-donor cap), reports reuses the shared picker.
+
+## DonorPicker contract (drop-in)
+
+```ts
+<DonorPicker value={number | null} onChange={(id: number | null) => void} />
+```
+
+Self-contained: own input, clear button, keyboard nav, loading/empty/error states. Emits donor id —
+exactly what `donorId` state and `useDonorStatement(donorId, range)` already expect. Already used in
+[donation-form.tsx:198](../src/features/donations/donation-form.tsx).
+
+## Commands
+
+- `pnpm run check` — Biome lint + format
+- `pnpm run build` — type-check + build
+- `pnpm run test` — unit tests
+- `pnpm run dev` — dev server (port 3000)
+
+## Project structure (files touched)
+
+All edits in one file: [src/features/reports/reports-page.tsx](../src/features/reports/reports-page.tsx).
+
+1. **Delete** the `DonorList` helper (lines 170–187).
+2. In `DonorStatementTab`:
+   - Remove `const { data: donorsPage } = useDonors()` (line 193) and
+     `const donors = donorsPage?.content ?? []` (line 199).
+   - Replace the whole `<Autocomplete.Root>…</Autocomplete.Root>` block (lines 204–231) with:
+     ```tsx
+     <div className="w-64">
+       <DonorPicker value={donorId} onChange={setDonorId} />
+     </div>
+     ```
+     (fixed-width wrapper keeps it tidy next to `DateRangePicker` in the `flex flex-wrap` row;
+     DonorPicker's root is fluid `flex-1`).
+   - Keep `donorId` state and `useDonorStatement(donorId, …)` untouched.
+3. **Remove now-orphaned imports** (made unused by this change only):
+   - `import { Autocomplete } from '@base-ui/react'` (line 1)
+   - `import type { DonorResponse } from '@jorgetroya80/donations-api-client'` (line 2)
+   - `CircleX` from the `lucide-react` import (line 4)
+   - `import { useDonors } from '@/features/donations/use-donations'` (line 18)
+4. **Add** `import { DonorPicker } from '@/features/donors/donor-picker'`.
+
+## Code style
+
+- Match surrounding patterns; surgical changes only (CLAUDE.md §3).
+- No new abstractions — DonorPicker is reused as-is.
+- React Compiler enabled (no manual memoization). Tailwind v4 classes. Biome formatting.
+
+## Testing strategy
+
+1. `pnpm run check` — no lint errors / no unused imports.
+2. `pnpm run build` — type-checks (DonorPicker `value`/`onChange` match `donorId` state).
+3. `pnpm run test` — existing suite green
+   ([donor-picker.test.tsx](../src/features/donors/donor-picker.test.tsx) unaffected).
+4. Manual (`pnpm run dev` → Reports → Donor statement tab): type a term → list comes from backend
+   search; pick a donor → statement loads; clear (X) → resets to "no donor selected".
+
+## Boundaries
+
+**Always:**
+
+- Keep the change scoped to `reports-page.tsx`.
+- Reuse the existing `DonorPicker` and search-capable `useDonors()` — no new picker code.
+
+**Ask first:**
+
+- Any change to `DonorPicker` itself or to `useDonorStatement`.
+- Touching i18n files.
+
+**Never:**
+
+- Delete the orphaned i18n keys `reports.searchDonor` / `reports.noDonorsFound` (DonorPicker uses
+  its own `donations.searchDonor` / `donations.noDonorsFound`). They become unused but removal is
+  out of scope — flag only.
+- Refactor adjacent tabs (`DonationSummaryTab`, `ExpenseSummaryTab`).

--- a/docs/plans/donor-picker-reports-plan.md
+++ b/docs/plans/donor-picker-reports-plan.md
@@ -1,0 +1,64 @@
+# Plan: Use DonorPicker in Reports donor-statement tab
+
+Source spec: [docs/SPEC-donor-picker-reports.md](../SPEC-donor-picker-reports.md)
+
+## Summary
+
+Single-file swap in [reports-page.tsx](../../src/features/reports/reports-page.tsx): replace the
+hand-rolled base-ui `Autocomplete` (client-side, 100-donor cap) with the existing server-side
+searchable [DonorPicker](../../src/features/donors/donor-picker.tsx). Drop-in — DonorPicker's
+`value: number | null` / `onChange: (id) => void` already match `donorId` state and
+`useDonorStatement(donorId, range)`.
+
+## Dependency graph
+
+```
+DonorPicker (exists, no change)  ─┐
+useDonors search hook (exists)   ─┤→  reports-page.tsx swap  →  manual verify
+useDonorStatement (exists)       ─┘
+```
+
+No build dependencies between subtasks — all edits land in one file, one vertical slice.
+Sequence is: edit → lint → typecheck → test → manual.
+
+## Phase 1 — Swap (one vertical slice)
+
+All in [src/features/reports/reports-page.tsx](../../src/features/reports/reports-page.tsx).
+
+1. Add `import { DonorPicker } from '@/features/donors/donor-picker'`.
+2. Delete `DonorList` helper (lines 170–187).
+3. In `DonorStatementTab`: remove `useDonors()` call (line 193) + `donors` derive (line 199);
+   replace `<Autocomplete.Root>…</Autocomplete.Root>` (lines 204–231) with:
+   ```tsx
+   <div className="w-64">
+     <DonorPicker value={donorId} onChange={setDonorId} />
+   </div>
+   ```
+4. Remove orphaned imports: `Autocomplete` (l1), `DonorResponse` (l2), `CircleX` from lucide (l4),
+   `useDonors` from `@/features/donations/use-donations` (l18).
+
+Keep `donorId` state + `useDonorStatement` untouched.
+
+### CHECKPOINT A — static
+
+- `pnpm run check` → no lint / no unused-import errors.
+- `pnpm run build` → type-checks clean.
+- `pnpm run test` → suite green.
+
+## Phase 2 — Verify behavior
+
+Manual (`pnpm run dev` → Reports → Donor statement tab):
+
+- Type term → list comes from backend search (not 100-cap client filter).
+- Pick donor → statement loads (`useDonorStatement` fires).
+- Clear (X) → resets to "no donor selected".
+
+### CHECKPOINT B — done
+
+All static checks pass + manual flow works → ready to commit.
+
+## Boundaries
+
+- Scope = `reports-page.tsx` only.
+- Do NOT delete orphaned i18n keys `reports.searchDonor` / `reports.noDonorsFound` (flag only).
+- Do NOT touch `DonorPicker`, `useDonorStatement`, or adjacent tabs.

--- a/src/features/donors/donor-picker.tsx
+++ b/src/features/donors/donor-picker.tsx
@@ -111,7 +111,7 @@ export function DonorPicker({ value, onChange }: DonorPickerProps) {
         aria-label={t('donations.clearDonor')}
         aria-hidden={value == null}
         tabIndex={value == null ? -1 : 0}
-        className={`transition-opacity duration-150 ${
+        className={`relative transition-opacity duration-150 before:absolute before:-inset-1 before:content-[''] ${
           value == null ? 'pointer-events-none opacity-0' : 'opacity-100'
         }`}
         onClick={() => {

--- a/src/features/reports/reports-page.test.tsx
+++ b/src/features/reports/reports-page.test.tsx
@@ -36,33 +36,32 @@ describe('ReportsPage', () => {
     expect(screen.getByText('Servicios')).toBeInTheDocument()
   })
 
-  it('switches to donor statement tab and shows autocomplete input', async () => {
+  it('switches to donor statement tab and shows donor picker input', async () => {
     const user = userEvent.setup()
     renderPage()
     await user.click(screen.getByText('Estado de cuenta del donante'))
     expect(
       screen.getByText('Seleccione un donante para ver su estado de cuenta')
     ).toBeInTheDocument()
-    expect(screen.getByPlaceholderText('Buscar donante...')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Buscar donante…')).toBeInTheDocument()
   })
 
-  it('loads donor statement when donor selected from autocomplete', async () => {
+  it('loads donor statement when donor selected from picker', async () => {
     const user = userEvent.setup()
     renderPage()
     await user.click(screen.getByText('Estado de cuenta del donante'))
 
-    const input = screen.getByPlaceholderText('Buscar donante...')
+    const input = screen.getByPlaceholderText('Buscar donante…')
 
-    // Type to filter donors
+    // Type to filter donors (server-side search)
+    await user.click(input)
     await user.type(input, 'Juan')
 
     // Donor option appears
-    await waitFor(() => {
-      expect(screen.getByText('Juan Pérez — 12345678A')).toBeInTheDocument()
-    })
+    const option = await screen.findByRole('option', { name: /Juan Pérez/ })
 
     // Click donor option
-    await user.click(screen.getByText('Juan Pérez — 12345678A'))
+    await user.click(option)
 
     // Statement loads
     await waitFor(() => {
@@ -77,7 +76,8 @@ describe('ReportsPage', () => {
     renderPage()
     await user.click(screen.getByText('Estado de cuenta del donante'))
 
-    const input = screen.getByPlaceholderText('Buscar donante...')
+    const input = screen.getByPlaceholderText('Buscar donante…')
+    await user.click(input)
     await user.type(input, 'zzznomatch')
 
     await waitFor(() => {
@@ -85,25 +85,24 @@ describe('ReportsPage', () => {
     })
   })
 
-  it('hides statement when input is cleared after donor selected', async () => {
+  it('hides statement when donor is cleared after selection', async () => {
     const user = userEvent.setup()
     renderPage()
     await user.click(screen.getByText('Estado de cuenta del donante'))
 
-    const input = screen.getByPlaceholderText('Buscar donante...')
+    const input = screen.getByPlaceholderText('Buscar donante…')
+    await user.click(input)
     await user.type(input, 'Juan')
 
-    await waitFor(() => {
-      expect(screen.getByText('Juan Pérez — 12345678A')).toBeInTheDocument()
-    })
-    await user.click(screen.getByText('Juan Pérez — 12345678A'))
+    const option = await screen.findByRole('option', { name: /Juan Pérez/ })
+    await user.click(option)
 
     await waitFor(() => {
       expect(screen.getByText('Diezmo')).toBeInTheDocument()
     })
 
-    // Clear the input
-    await user.clear(input)
+    // Clear the selected donor via the clear button
+    await user.click(screen.getByRole('button', { name: 'Quitar donante' }))
 
     // Statement should be hidden; prompt message should reappear
     await waitFor(() => {

--- a/src/features/reports/reports-page.tsx
+++ b/src/features/reports/reports-page.tsx
@@ -176,7 +176,7 @@ function DonorStatementTab() {
   return (
     <div className="space-y-4">
       <div className="flex flex-wrap items-center gap-4">
-        <div className="w-64">
+        <div className="min-w-56 flex-1 sm:max-w-sm">
           <DonorPicker value={donorId} onChange={setDonorId} />
         </div>
         <DateRangePicker

--- a/src/features/reports/reports-page.tsx
+++ b/src/features/reports/reports-page.tsx
@@ -1,7 +1,4 @@
-import { Autocomplete } from '@base-ui/react'
-import type { DonorResponse } from '@jorgetroya80/donations-api-client'
 import dayjs from 'dayjs'
-import { CircleX } from 'lucide-react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { DateRangePicker } from '@/components/date-range-picker'
@@ -15,7 +12,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
-import { useDonors } from '@/features/donations/use-donations'
+import { DonorPicker } from '@/features/donors/donor-picker'
 import { currentMonthRange, formatCurrency } from '@/lib/formatters'
 import {
   useDonationReport,
@@ -167,68 +164,21 @@ function ExpenseSummaryTab() {
   )
 }
 
-function DonorList({ onSelect }: { onSelect: (id: number | null) => void }) {
-  const filtered = Autocomplete.useFilteredItems<DonorResponse>()
-  return (
-    <Autocomplete.List>
-      {filtered.map((donor, i) => (
-        <Autocomplete.Item
-          key={donor.id}
-          value={donor}
-          index={i}
-          onClick={() => onSelect(donor.id ?? null)}
-          className="cursor-pointer px-3 py-2 text-sm data-highlighted:bg-accent"
-        >
-          {donor.fullName} — {donor.nationalId}
-        </Autocomplete.Item>
-      ))}
-    </Autocomplete.List>
-  )
-}
-
 function DonorStatementTab() {
   const { t } = useTranslation()
   const [range, setRange] = useState(currentMonthRange)
   const [donorId, setDonorId] = useState<number | null>(null)
-  const { data: donorsPage } = useDonors()
   const { data, isLoading, error } = useDonorStatement(donorId, {
     from: formatDate(range.from),
     to: formatDate(range.to),
   })
 
-  const donors = donorsPage?.content ?? []
-
   return (
     <div className="space-y-4">
       <div className="flex flex-wrap items-center gap-4">
-        <Autocomplete.Root
-          items={donors}
-          itemToStringValue={(d) => d.fullName ?? ''}
-          onValueChange={(v) => {
-            if (!v) setDonorId(null)
-          }}
-        >
-          <Autocomplete.InputGroup className="grid items-center">
-            <Autocomplete.Input
-              placeholder={t('reports.searchDonor')}
-              aria-label={t('reports.searchDonor')}
-              className="[grid-area:1/1] rounded-lg border border-input bg-background px-3 py-1.5 pr-8 text-sm"
-            />
-            <Autocomplete.Clear className="[grid-area:1/1] mr-3 cursor-pointer justify-self-end text-muted-foreground transition-colors hover:text-foreground">
-              <CircleX size={15} />
-            </Autocomplete.Clear>
-          </Autocomplete.InputGroup>
-          <Autocomplete.Portal>
-            <Autocomplete.Positioner>
-              <Autocomplete.Popup className="z-50 min-w-(--anchor-width) rounded-lg border border-input bg-background shadow-md mt-1">
-                <DonorList onSelect={setDonorId} />
-                <Autocomplete.Empty className="px-3 py-2 text-sm text-muted-foreground">
-                  {t('reports.noDonorsFound')}
-                </Autocomplete.Empty>
-              </Autocomplete.Popup>
-            </Autocomplete.Positioner>
-          </Autocomplete.Portal>
-        </Autocomplete.Root>
+        <div className="w-64">
+          <DonorPicker value={donorId} onChange={setDonorId} />
+        </div>
         <DateRangePicker
           from={range.from}
           to={range.to}


### PR DESCRIPTION
## Summary

Replaces the hand-rolled base-ui `Autocomplete` in the reports **donor-statement** tab with the existing server-side searchable `DonorPicker`. Donor search now hits the backend by term instead of fetching the first 100 donors and filtering client-side.

## Changes

- **Swap picker** ([reports-page.tsx](../blob/feat-use-donor-picker-in-report/src/features/reports/reports-page.tsx)): delete `DonorList` helper + `Autocomplete` block + eager `useDonors()` (100-donor cap); drop in `<DonorPicker value={donorId} onChange={setDonorId} />`. Removed 4 orphaned imports. `donorId` state + `useDonorStatement` untouched.
- **Responsive width**: wrapper `min-w-56 flex-1 sm:max-w-sm` — picker grows to fill the filter row, wraps cleanly on narrow screens.
- **Hit area fix** (`donor-picker.tsx`): extend clear button from `size-8` (32px) to the 40×40 minimum via a `-inset-1` pseudo-element.

## Behavior / perf

- Search by term via backend (no 100-donor cap).
- Picker fetches only when opened (`enabled: open`), debounced 250ms, `size: 10` — strictly fewer/smaller requests than the previous eager load.

## Tests

- Updated donor-statement integration tests for the new component (placeholder, `role=option`, X-button clear).

