### PR TITLE
feat(deploy): deploy frontend to Render (Docker web service, same-origin /api proxy)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,10 @@ FROM nginx:1.27-alpine
 LABEL org.opencontainers.image.title="donations-frontend" \
       org.opencontainers.image.source="https://github.com/jorgetroya80/donations-frontend"
 
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY default.conf.template /etc/nginx/templates/default.conf.template
 COPY --from=build /app/dist /usr/share/nginx/html
+
+ENV PORT=80 API_UPSTREAM=http://api:8081 API_HOST=api
 
 EXPOSE 80
 

--- a/default.conf.template
+++ b/default.conf.template
@@ -1,5 +1,5 @@
 server {
-    listen 80;
+    listen ${PORT};
     root /usr/share/nginx/html;
     index index.html;
 
@@ -15,10 +15,11 @@ server {
     add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'" always;
 
     location /api/ {
-        proxy_pass http://api:8081;
+        proxy_pass ${API_UPSTREAM};
+        proxy_ssl_server_name on;
         proxy_http_version 1.1;
         proxy_set_header Connection "";
-        proxy_set_header Host $host;
+        proxy_set_header Host ${API_HOST};
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,13 @@
 services:
   frontend:
     image: jorgetroya/donations-frontend:latest
-    platform: linux/amd64
     build:
       context: .
       args:
         VITE_API_URL: ${VITE_API_URL:-}
       secrets:
-        - node_auth_token
+        - source: node_auth_token
+          target: NODE_AUTH_TOKEN
     ports:
       - '8080:80'
     depends_on:
@@ -25,7 +25,6 @@ services:
 
   api:
     image: jorgetroya/donations-api:${DONATIONS_API_VERSION:-1.7.1}
-    platform: linux/amd64
     pull_policy: always
     ports:
       - '8081:8081'

--- a/docs/PRD-deploy-render.md
+++ b/docs/PRD-deploy-render.md
@@ -1,0 +1,92 @@
+# PRD: Deploy frontend to Render (Docker web service, same-origin /api proxy)
+
+**GitHub Issue:** https://github.com/jorgetroya80/donations-frontend/issues/146
+
+## Problem Statement
+
+The frontend must deploy to Render alongside the API. The SPA calls the API at **same-origin `/api/`** through the nginx reverse proxy, and that property is load-bearing:
+
+- CSP is strict `connect-src 'self'` (`nginx.conf`) → the browser blocks cross-origin calls to the API.
+- The session cookie is `SameSite=Lax; Secure` → it does not travel to a different domain.
+- The API `prod` profile has CORS **disabled**.
+
+Today the proxy upstream is hardcoded to the docker-compose service (`proxy_pass http://api:8081;`), which does not exist on Render. The listen port is hardcoded to `80`, while Render injects `$PORT`. The same image and `nginx.conf` are reused by `docker-compose.yml` for local full-stack dev, so any host-specific value baked into the image breaks local development.
+
+## Solution
+
+Ship one provider-agnostic Docker image: serve the built SPA via nginx and reverse-proxy `/api/` to a **configurable upstream** on a **configurable port**, with all environment-specific values injected via env vars at container start (`envsubst` + entrypoint). The same image then runs unchanged on local docker-compose, Render, or any future host — only env vars differ. Add a `render.yaml` to declare the web service. The API must be deployed first (donations-api#42) since the proxy needs it live.
+
+## User Stories
+
+1. As an operator, I want the nginx upstream and listen port configurable via env vars, so the same image runs on local compose and Render without code changes.
+2. As an operator, I want to move to another hosting provider by only changing env vars, so the image is not coupled to Render.
+3. As a developer, I want `docker compose up` to keep working with no config edits, so local full-stack dev is unaffected (defaults reproduce current behavior).
+4. As a security-conscious developer, I want CSP strict and the API same-origin preserved, so cookies/CSP/CORS keep working without touching the API.
+5. As an operator, I want a `render.yaml` declaring a Docker web service with health check and region, so deploys are reproducible.
+
+## Implementation Decisions
+
+### nginx config (template, processed by the nginx image's built-in entrypoint)
+The `nginx:1.27-alpine` image ships `20-envsubst-on-templates.sh`, which auto-runs `envsubst` on every `*.template` in `/etc/nginx/templates/` and writes the result to `/etc/nginx/conf.d/` at container start. No custom entrypoint needed.
+
+Rename `nginx.conf` → `default.conf.template` (copied to `/etc/nginx/templates/`). Parameterize exactly three values; leave all else intact:
+- `listen ${PORT};`
+- `proxy_pass ${API_UPSTREAM};`
+- `proxy_set_header Host ${API_HOST};` (upstream hostname; for the local http upstream the API ignores Host, so any value works)
+- Add `proxy_ssl_server_name on;` (harmless for an http upstream, required for https/SNI on Render).
+- No allow-list needed: the built-in script substitutes **only env vars that are actually defined**, so nginx runtime vars (`$remote_addr`, `$proxy_add_x_forwarded_for`, `$uri`, cache vars) are left intact automatically (they are not env vars).
+
+### Dockerfile (final stage only)
+- `COPY default.conf.template /etc/nginx/templates/default.conf.template` (replaces the old `COPY nginx.conf /etc/nginx/conf.d/default.conf`).
+- Add `ENV PORT=80 API_UPSTREAM=http://api:8081 API_HOST=api` — defaults that reproduce current compose behavior. Render overrides `PORT` (auto-injected) and `API_UPSTREAM`/`API_HOST`.
+- Keep `EXPOSE 80` (informational) and the existing `HEALTHCHECK`/`CMD` — no entrypoint changes.
+- Build stage unchanged; no `VITE_*` runtime config needed (SPA calls `/api` relative).
+
+### `render.yaml` (new)
+```yaml
+services:
+  - type: web
+    name: donations-frontend
+    runtime: docker
+    dockerfilePath: ./Dockerfile
+    plan: free
+    region: frankfurt        # match API region for low proxy latency
+    autoDeploy: true
+    healthCheckPath: /
+    envVars:
+      - key: API_UPSTREAM
+        value: https://<CONFIRM>.onrender.com   # exact API host from donations-api#42
+      - key: API_HOST
+        value: <CONFIRM>.onrender.com
+```
+- `PORT` is injected by Render automatically — do not set it.
+- Exact API hostname is a `<CONFIRM>` placeholder pending donations-api#42.
+
+### `docker-compose.yml`
+- No change required: defaults reproduce current behavior. Optionally set `API_UPSTREAM`/`API_HOST` explicitly for clarity.
+
+## Testing Strategy
+
+Local (before deploy):
+1. `docker compose up --build` → SPA loads at `http://localhost:8080`.
+2. Log in → DevTools Network: `/api/v1/...` same-origin, 200, session cookie set; no CSP/CORS errors; deep-link refresh does not 404.
+3. `docker compose exec frontend cat /etc/nginx/conf.d/default.conf` → runtime `$` vars intact, upstream/port substituted.
+
+Render (after API live):
+4. Set `API_UPSTREAM`/`API_HOST` to confirmed API host; deploy.
+5. Open `https://donations-frontend.onrender.com` → SPA loads (`$PORT` auto-detect works).
+6. Repeat login/network checks from step 2.
+7. If login fails on cookie scope: add `proxy_cookie_domain ${API_HOST} $host;` to the `/api/` block.
+
+## Boundaries
+
+- **Always:** preserve same-origin `/api/` proxy and strict CSP; keep config env-driven (no host names baked into the image).
+- **Ask first:** changing CSP/security headers; touching the API or its CORS; switching from Docker web service to Static Site.
+- **Never:** hardcode the Render API URL into `nginx.conf`/image; break local compose defaults; commit secrets.
+
+## Execution Order
+1. Rename `nginx.conf` → `default.conf.template`, parameterize the three values.
+2. Edit `Dockerfile` final stage (template copy path + `ENV` defaults).
+3. Add `render.yaml`.
+4. Run local verification (Testing Strategy steps 1–3).
+5. Deploy API first (donations-api#42), then Render deploy + verify (steps 4–7).

--- a/docs/plans/deploy-render.md
+++ b/docs/plans/deploy-render.md
@@ -1,0 +1,52 @@
+# PLAN: Deploy donations-frontend to Render
+
+Spec: [docs/PRD-deploy-render.md](../PRD-deploy-render.md) · Issue [#146](https://github.com/jorgetroya80/donations-frontend/issues/146)
+
+## Context
+
+Deploy the SPA to Render as a Docker web service that proxies `/api/` same-origin to the API (preserves strict CSP, `SameSite=Lax` cookie, API CORS-disabled). Current `nginx.conf` hardcodes upstream `http://api:8081` and `listen 80`; the same image is reused by `docker-compose.yml` for local dev. Make config provider-agnostic via env vars + the nginx image's built-in template entrypoint, then add `render.yaml`. API deploys first (donations-api#42).
+
+## Dependency graph
+
+```
+default.conf.template ──▶ Dockerfile (COPY template + ENV defaults)
+                              │
+                              ▼
+                    docker-compose build ──▶ [CHECKPOINT: local verify]
+                              │
+                              ▼
+                         render.yaml ──▶ [CHECKPOINT: Render verify]
+```
+- `render.yaml` is an independent file but only meaningful once the image behaves correctly → ordered after local verify.
+
+## Tasks (vertical slices)
+
+### Task 1 — Env-driven nginx proxy (complete local path)
+Files: `nginx.conf` → `default.conf.template`, `Dockerfile`.
+- Rename `nginx.conf` to `default.conf.template`; parameterize `listen ${PORT};`, `proxy_pass ${API_UPSTREAM};`, `proxy_set_header Host ${API_HOST};`; add `proxy_ssl_server_name on;`. Leave all other directives (CSP, headers, gzip, `try_files`, cache, runtime `$` vars) untouched.
+- Dockerfile final stage: replace `COPY nginx.conf /etc/nginx/conf.d/default.conf` with `COPY default.conf.template /etc/nginx/templates/default.conf.template`; add `ENV PORT=80 API_UPSTREAM=http://api:8081 API_HOST=api`. No CMD/ENTRYPOINT/HEALTHCHECK change.
+
+Acceptance:
+- `docker compose up --build` boots; frontend healthy.
+- SPA loads at `http://localhost:8080`; login works; `/api/v1/...` same-origin 200, session cookie set; no CSP/CORS errors; deep-link refresh ≠ 404.
+- `docker compose exec frontend cat /etc/nginx/conf.d/default.conf` → `listen 80;`, `proxy_pass http://api:8081;`, `Host api`; runtime vars (`$remote_addr`, `$uri`, …) intact.
+
+Verify: commands above.
+
+### Task 2 — Render service declaration
+File: `render.yaml` (new).
+- type web / runtime docker / `dockerfilePath: ./Dockerfile` / plan free / `region: frankfurt` / `autoDeploy: true` / `healthCheckPath: /`.
+- `envVars`: `API_UPSTREAM=https://<CONFIRM>.onrender.com`, `API_HOST=<CONFIRM>.onrender.com`. Do **not** set `PORT` (Render injects it).
+
+Acceptance:
+- `render.yaml` valid YAML, fields per spec.
+- (Deferred to deploy) `<CONFIRM>` replaced with API host from donations-api#42.
+
+Verify: YAML lint / `docker compose config` unaffected.
+
+## Checkpoints
+- **CP1 (gate before Render):** Task 1 local verification fully green. Block Task 2 deploy if any acceptance item fails.
+- **CP2 (Render, after API live):** deploy API first; set real `API_UPSTREAM`/`API_HOST`; open `https://donations-frontend.onrender.com` → SPA loads (`$PORT` auto-detect), login/network checks pass. Fallback: add `proxy_cookie_domain ${API_HOST} $host;` if cookie scope blocks login.
+
+## Out of scope
+API changes, CORS, CSP relaxation, Static Site approach.

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,14 @@
+services:
+  - type: web
+    name: donations-frontend
+    runtime: docker
+    dockerfilePath: ./Dockerfile
+    plan: free
+    region: frankfurt
+    autoDeploy: true
+    healthCheckPath: /
+    envVars:
+      - key: API_UPSTREAM
+        sync: false
+      - key: API_HOST
+        sync: false


### PR DESCRIPTION
## What

Deploy the frontend to Render as a **Docker web service** (not Static Site) that reverse-proxies `/api/` **same-origin** to the API — preserving strict CSP (`connect-src 'self'`), the `SameSite=Lax; Secure` session cookie, and the API's disabled CORS, without touching the API.

## Changes

- **`nginx.conf` → `default.conf.template`**: parameterize `listen ${PORT}`, `proxy_pass ${API_UPSTREAM}`, `proxy_set_header Host ${API_HOST}`; add `proxy_ssl_server_name on` (SNI for https upstream). Everything else unchanged.
- **`Dockerfile`**: template copied to `/etc/nginx/templates/` so the nginx image's built-in envsubst entrypoint renders it at start. `ENV PORT=80 API_UPSTREAM=http://api:8081 API_HOST=api` defaults (local compose). No custom entrypoint.
- **`render.yaml`** (new): Docker web service, region frankfurt, `autoDeploy`, `healthCheckPath: /`. `API_UPSTREAM`/`API_HOST` declared `sync: false` (set in dashboard, not git). `PORT` injected by Render.
- **`docker-compose.yml`**: fix pre-existing build-secret id mismatch (`node_auth_token` → `target: NODE_AUTH_TOKEN`); drop forced `platform: linux/amd64` pins (both images are multi-arch → run native, no arm64 emulation).
- **docs**: `docs/PRD-deploy-render.md`, `docs/plans/deploy-render.md`.

Provider-agnostic: same image runs on local compose and Render (or any host) via env vars only.

## Related
- Closes #146

## Verification

- **CP1 (local, done)**: `docker compose up --build` → SPA loads, login works, `/api/v1/...` same-origin 200, cookie set; rendered config shows `listen 80; proxy_pass http://api:8081; Host api` with runtime `$` vars intact.
- **CP2 (Render, pending)**: API deployed first (donations-api#42); set `API_UPSTREAM=https://donations-api-fikm.onrender.com`, `API_HOST=donations-api-fikm.onrender.com` in dashboard; open Render URL, login, verify same-origin `/api`. Fallback: add `proxy_cookie_domain ${API_HOST} $host;` if cookie scope blocks login.

