### PR TITLE
fix(docker): add BuildKit syntax directive for Render build secrets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM node:24-alpine AS build
 
 WORKDIR /app


### PR DESCRIPTION
## Problem

Render build failed at `pnpm fetch`:
```
process "/bin/sh -c NODE_AUTH_TOKEN=$(cat /run/secrets/NODE_AUTH_TOKEN) pnpm fetch" did not complete successfully: exit code: 1
cat: can't open '/run/secrets/NODE_AUTH_TOKEN': No such file or directory
```

Render's Docker builder only enables `--mount=type=secret` when the Dockerfile declares an explicit BuildKit `# syntax` directive. Without it the secret mount is empty. CI (docker/build-push-action) and local compose worked because buildx enables secret mounts by default.

## Fix

Add `# syntax=docker/dockerfile:1` as the first line of the Dockerfile.

## Related

- Follow-up to #146 / #147.

## Also required (Render dashboard, not code)

Add a **Secret File** named `NODE_AUTH_TOKEN` (content = GitHub Packages PAT). Render mounts it at `/run/secrets/NODE_AUTH_TOKEN`, matching the Dockerfile.

