### PR TITLE
fix(deps): bump undici to 7.28.0 (CVE-2026-9697)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1816,8 +1816,8 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
-  undici@7.25.0:
-    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   until-async@3.0.2:
@@ -2976,7 +2976,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.25.0
+      undici: 7.28.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -3435,7 +3435,7 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici@7.25.0: {}
+  undici@7.28.0: {}
 
   until-async@3.0.2: {}
 


### PR DESCRIPTION
## What

Bumps `undici` `7.25.0` → `7.28.0` to resolve Dependabot alert [#14](https://github.com/jorgetroya80/donations-frontend/security/dependabot/14).

## Why

**GHSA-vmh5-mc38-953g / CVE-2026-9697** (high, CVSS 7.4) — undici's `ProxyAgent` silently drops the `requestTls` option on a SOCKS5 proxy URI, falling back to Node's default trust store and bypassing a user-configured CA pin (MITM on the tunneled HTTPS exchange).

- Transitive, **dev-scoped** dependency via `jsdom@29.0.2` (vitest DOM env).
- Real exposure here is effectively nil — the vulnerable path needs a SOCKS5 proxy + `requestTls` pinning, which jsdom's test-time usage does not do, and undici never ships to production.
- jsdom's range `^7.24.5` already permits 7.28.0, so this is a **lockfile-only** change.

## Verification

- `pnpm install --frozen-lockfile` → clean
- `pnpm run test` → 328 passed (49 files)

Alert #14 auto-closes once merged to `main`.

