### PR TITLE
feat(donors): add per-donor statement link to the reports donor-statement tab

### DIFF
--- a/docs/plans/query-donations-by-person.md
+++ b/docs/plans/query-donations-by-person.md
@@ -1,0 +1,101 @@
+# Plan: Per-donor "Ver donaciones" action on DonorsPage
+
+Branch: `feat-query-donations-by-person`
+
+## Summary
+
+Add a per-row action to [donors-page.tsx](../../src/features/donors/donors-page.tsx) that lets the user
+jump from a donor in the list to that donor's date-range statement. Rather than rebuild any date/query
+UI, the action navigates to the **existing** Reports donor-statement screen with the donor preselected:
+`` `/reports?tab=donor-statement&donorId=${donor.id}` ``.
+
+The target screen already does everything — date-range picking, querying, currency/date formatting, and
+empty/error/loading states — and already reads `?tab=` and `?donorId=` from the URL. So this is navigation
+only: one new `Link` per row, one i18n key, one test. No new hooks, components, or state.
+
+## Why it works with zero changes to the Reports side (verified)
+
+- [reports-page.tsx](../../src/features/reports/reports-page.tsx) reads `?tab=` and activates the
+  `donor-statement` tab when `tab=donor-statement`.
+- [donor-statement-tab.tsx](../../src/features/reports/donor-statement-tab.tsx) reads `?donorId=`,
+  validates it (positive integer), and drives `useDonorStatement(donorId, range)`; the query fires as soon
+  as a valid `donorId` is present. Range defaults to `currentMonthRange()`.
+- [donor-picker.tsx](../../src/features/donors/donor-picker.tsx) resolves the selected donor's name via
+  `useDonor(value)` (`:27`, `:81`), so a donor arriving via URL displays correctly even though the picker
+  is a search combobox.
+
+## Dependency graph
+
+```
+reports-page.tsx / donor-statement-tab.tsx  (exist, no change)  ─┐
+DonorPicker name resolution via useDonor    (exists, no change)  ─┤→  donors-page.tsx  →  verify
+i18n key donors.statementLabel              (new)               ─┘
+```
+
+All edits land in one component + one locale file — a single vertical slice.
+Sequence: edit → i18n → test → lint → typecheck → manual.
+
+## Phase 1 — Add the action (one vertical slice)
+
+### 1. [src/features/donors/donors-page.tsx](../../src/features/donors/donors-page.tsx)
+
+Beside the existing edit `Link` in the Actions cell (`donors-page.tsx:99-112`):
+
+- Add `FileBarChart` to the existing `import { Pencil, Plus } from 'lucide-react'` (same icon the
+  donor-statement tab uses — keeps the visual association).
+- Wrap the two actions in `<div className="flex gap-1">`.
+- New `Link`:
+  ```tsx
+  <Link
+    to={`/reports?tab=donor-statement&donorId=${donor.id}`}
+    className={buttonVariants({ variant: 'ghost', size: 'icon' })}
+    aria-label={t('donors.statementLabel')}
+  >
+    <FileBarChart size={14} aria-hidden="true" />
+  </Link>
+  ```
+- Widen the Actions column header from `w-16` to `w-24` (`donors-page.tsx:82`) to fit two icon buttons.
+
+### 2. [src/locales/es.json](../../src/locales/es.json)
+
+Add under `donors`, next to `donors.editLabel` (`es.json:112`):
+
+```json
+"statementLabel": "Ver donaciones"
+```
+
+Existing donor-statement strings live under `reports.*` and are reused as-is on the target screen — no new
+`reports` keys needed.
+
+### 3. [src/features/donors/donors-page.test.tsx](../../src/features/donors/donors-page.test.tsx)
+
+Add a test asserting each donor row renders a link with
+`href="/reports?tab=donor-statement&donorId=<id>"`, following the existing test's row/link queries.
+
+### CHECKPOINT A — static + unit
+
+- `pnpm run test` → new + existing `donors-page.test.tsx` green.
+- `pnpm run check` → Biome lint/format clean, new import ordered, no unused imports.
+- `pnpm run build` → type-checks clean.
+
+## Phase 2 — Verify behavior
+
+Manual (`pnpm run dev` → `/donors`):
+
+- Each row shows two ghost icon buttons: edit (pencil) + statement (bar chart).
+- Click the statement icon → lands on `/reports?tab=donor-statement&donorId=<id>` with the
+  donor-statement tab active, the donor's name shown in the picker, and the current-month statement loaded.
+- Adjust the date range → results update.
+- A11y: the statement link exposes `aria-label="Ver donaciones"`; icon is `aria-hidden`.
+
+### CHECKPOINT B — done
+
+Static checks pass + manual flow works → ready to commit.
+
+## Boundaries
+
+- Scope = `donors-page.tsx` + `es.json` + `donors-page.test.tsx`.
+- Do NOT add a modal, inline expander, or new query hook — navigation only (chosen approach).
+- Do NOT touch the Reports screen, `useDonorStatement`, or `DonorPicker`.
+- Do NOT persist the date range in the URL — the donor-statement tab keeps range in local state; leave that
+  behavior as-is.

--- a/src/features/donors/donors-page.test.tsx
+++ b/src/features/donors/donors-page.test.tsx
@@ -127,6 +127,25 @@ describe('DonorsPage', () => {
     })
   })
 
+  it('shows statement links to the report donor-statement tab for each row', async () => {
+    renderWithProviders(<DonorsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Juan Pérez')).toBeInTheDocument()
+    })
+    const statementLinks = screen.getAllByRole('link', {
+      name: 'Ver donaciones',
+    })
+    expect(statementLinks).toHaveLength(2)
+    expect(statementLinks[0]).toHaveAttribute(
+      'href',
+      '/reports?tab=donor-statement&donorId=1'
+    )
+    expect(statementLinks[1]).toHaveAttribute(
+      'href',
+      '/reports?tab=donor-statement&donorId=2'
+    )
+  })
+
   it('edit links have descriptive aria-labels', async () => {
     renderWithProviders(<DonorsPage />)
     await waitFor(() => {

--- a/src/features/donors/donors-page.test.tsx
+++ b/src/features/donors/donors-page.test.tsx
@@ -7,7 +7,7 @@ import { DonorsPage } from './donors-page'
 beforeEach(() => {
   localStorage.setItem(
     'auth_user',
-    JSON.stringify({ username: 'admin', roles: ['ADMIN'] })
+    JSON.stringify({ username: 'treasurer', roles: ['TREASURER'] })
   )
 })
 
@@ -133,7 +133,7 @@ describe('DonorsPage', () => {
       expect(screen.getByText('Juan Pérez')).toBeInTheDocument()
     })
     const statementLinks = screen.getAllByRole('link', {
-      name: 'Ver donaciones',
+      name: /Ver donaciones/,
     })
     expect(statementLinks).toHaveLength(2)
     expect(statementLinks[0]).toHaveAttribute(
@@ -144,6 +144,24 @@ describe('DonorsPage', () => {
       'href',
       '/reports?tab=donor-statement&donorId=2'
     )
+  })
+
+  it('hides statement links for users without report access', async () => {
+    localStorage.setItem(
+      'auth_user',
+      JSON.stringify({ username: 'operator', roles: ['OPERATOR'] })
+    )
+    renderWithProviders(<DonorsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Juan Pérez')).toBeInTheDocument()
+    })
+    expect(
+      screen.queryByRole('link', { name: /Ver donaciones/ })
+    ).not.toBeInTheDocument()
+    // Edit links remain available to data recorders.
+    expect(
+      screen.getAllByRole('link', { name: /Editar donante/ })
+    ).toHaveLength(2)
   })
 
   it('edit links have descriptive aria-labels', async () => {

--- a/src/features/donors/donors-page.tsx
+++ b/src/features/donors/donors-page.tsx
@@ -16,13 +16,16 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
+import { useAuth } from '@/features/auth/auth-context'
 import { getProblemMessage } from '@/lib/get-problem-message'
+import { canViewReports } from '@/lib/permissions'
 import { usePageParam } from '@/lib/use-page-param'
 import { useSort } from '@/lib/use-sort'
 import { useDonors } from './use-donors'
 
 export function DonorsPage() {
   const { t } = useTranslation()
+  const { user } = useAuth()
   const navigate = useNavigate()
   const { page, setPage } = usePageParam()
   const { sort, toggleSort, sortIndicator, ariaSort } = useSort(
@@ -98,16 +101,20 @@ export function DonorsPage() {
                   </TableCell>
                   <TableCell>
                     <div className="flex gap-1">
-                      <Link
-                        to={`/reports?tab=donor-statement&donorId=${donor.id}`}
-                        className={buttonVariants({
-                          variant: 'ghost',
-                          size: 'icon',
-                        })}
-                        aria-label={t('donors.statementLabel')}
-                      >
-                        <FileBarChart size={14} aria-hidden="true" />
-                      </Link>
+                      {canViewReports(user) && (
+                        <Link
+                          to={`/reports?tab=donor-statement&donorId=${donor.id}`}
+                          className={buttonVariants({
+                            variant: 'ghost',
+                            size: 'icon',
+                          })}
+                          aria-label={t('donors.statementLabel', {
+                            name: donor.fullName,
+                          })}
+                        >
+                          <FileBarChart size={14} aria-hidden="true" />
+                        </Link>
+                      )}
                       <Link
                         to={`/donors/${donor.id}/edit`}
                         className={buttonVariants({

--- a/src/features/donors/donors-page.tsx
+++ b/src/features/donors/donors-page.tsx
@@ -1,4 +1,4 @@
-import { Pencil, Plus } from 'lucide-react'
+import { FileBarChart, Pencil, Plus } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Link, useNavigate } from 'react-router'
 import { EmptyState } from '@/components/empty-state'
@@ -79,7 +79,7 @@ export function DonorsPage() {
                 <TableHead>{t('donors.email')}</TableHead>
                 <TableHead>{t('donors.phone')}</TableHead>
                 <TableHead>{t('donors.status')}</TableHead>
-                <TableHead className="w-16">{t('common.actions')}</TableHead>
+                <TableHead className="w-24">{t('common.actions')}</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -97,18 +97,30 @@ export function DonorsPage() {
                     </Badge>
                   </TableCell>
                   <TableCell>
-                    <Link
-                      to={`/donors/${donor.id}/edit`}
-                      className={buttonVariants({
-                        variant: 'ghost',
-                        size: 'icon',
-                      })}
-                      aria-label={t('donors.editLabel', {
-                        name: donor.fullName,
-                      })}
-                    >
-                      <Pencil size={14} aria-hidden="true" />
-                    </Link>
+                    <div className="flex gap-1">
+                      <Link
+                        to={`/reports?tab=donor-statement&donorId=${donor.id}`}
+                        className={buttonVariants({
+                          variant: 'ghost',
+                          size: 'icon',
+                        })}
+                        aria-label={t('donors.statementLabel')}
+                      >
+                        <FileBarChart size={14} aria-hidden="true" />
+                      </Link>
+                      <Link
+                        to={`/donors/${donor.id}/edit`}
+                        className={buttonVariants({
+                          variant: 'ghost',
+                          size: 'icon',
+                        })}
+                        aria-label={t('donors.editLabel', {
+                          name: donor.fullName,
+                        })}
+                      >
+                        <Pencil size={14} aria-hidden="true" />
+                      </Link>
+                    </div>
                   </TableCell>
                 </TableRow>
               ))}

--- a/src/features/reports/reports-page.test.tsx
+++ b/src/features/reports/reports-page.test.tsx
@@ -34,7 +34,9 @@ describe('ReportsPage', () => {
     expect(screen.getByText('Reportes')).toBeInTheDocument()
     expect(screen.getByText('Resumen de donaciones')).toBeInTheDocument()
     expect(screen.getByText('Resumen de gastos')).toBeInTheDocument()
-    expect(screen.getByText('Resumen donativos por donante')).toBeInTheDocument()
+    expect(
+      screen.getByText('Resumen donativos por donante')
+    ).toBeInTheDocument()
   })
 
   it('shows donation summary tab by default with data', async () => {

--- a/src/features/reports/reports-page.test.tsx
+++ b/src/features/reports/reports-page.test.tsx
@@ -187,6 +187,14 @@ describe('ReportsPage', () => {
     expect(screen.getByText('Total general')).toBeInTheDocument()
   })
 
+  it('preselects the donor name in the picker from a deep link', async () => {
+    renderPage('/reports?tab=donor-statement&donorId=1')
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Juan Pérez')).toBeInTheDocument()
+    })
+  })
+
   it('pushes history on tab switch so Back returns to the previous tab', async () => {
     const user = userEvent.setup()
     renderPage()

--- a/src/features/reports/reports-page.test.tsx
+++ b/src/features/reports/reports-page.test.tsx
@@ -34,7 +34,7 @@ describe('ReportsPage', () => {
     expect(screen.getByText('Reportes')).toBeInTheDocument()
     expect(screen.getByText('Resumen de donaciones')).toBeInTheDocument()
     expect(screen.getByText('Resumen de gastos')).toBeInTheDocument()
-    expect(screen.getByText('Estado de cuenta del donante')).toBeInTheDocument()
+    expect(screen.getByText('Resumen donativos por donante')).toBeInTheDocument()
   })
 
   it('shows donation summary tab by default with data', async () => {
@@ -59,7 +59,7 @@ describe('ReportsPage', () => {
   it('switches to donor statement tab and shows donor picker input', async () => {
     const user = userEvent.setup()
     renderPage()
-    await user.click(screen.getByText('Estado de cuenta del donante'))
+    await user.click(screen.getByText('Resumen donativos por donante'))
     expect(
       screen.getByText('Seleccione un donante para ver su estado de cuenta')
     ).toBeInTheDocument()
@@ -69,7 +69,7 @@ describe('ReportsPage', () => {
   it('loads donor statement when donor selected from picker', async () => {
     const user = userEvent.setup()
     renderPage()
-    await user.click(screen.getByText('Estado de cuenta del donante'))
+    await user.click(screen.getByText('Resumen donativos por donante'))
 
     const input = screen.getByPlaceholderText('Buscar donante…')
 
@@ -94,7 +94,7 @@ describe('ReportsPage', () => {
   it('shows no donors found message when search matches nothing', async () => {
     const user = userEvent.setup()
     renderPage()
-    await user.click(screen.getByText('Estado de cuenta del donante'))
+    await user.click(screen.getByText('Resumen donativos por donante'))
 
     const input = screen.getByPlaceholderText('Buscar donante…')
     await user.click(input)
@@ -108,7 +108,7 @@ describe('ReportsPage', () => {
   it('hides statement when donor is cleared after selection', async () => {
     const user = userEvent.setup()
     renderPage()
-    await user.click(screen.getByText('Estado de cuenta del donante'))
+    await user.click(screen.getByText('Resumen donativos por donante'))
 
     const input = screen.getByPlaceholderText('Buscar donante…')
     await user.click(input)
@@ -150,7 +150,7 @@ describe('ReportsPage', () => {
   it('initializes the active tab from the URL', () => {
     renderPage('/reports?tab=donor-statement')
     expect(
-      screen.getByRole('tab', { name: 'Estado de cuenta del donante' })
+      screen.getByRole('tab', { name: 'Resumen donativos por donante' })
     ).toHaveAttribute('aria-selected', 'true')
     expect(screen.getByPlaceholderText('Buscar donante…')).toBeInTheDocument()
   })
@@ -224,7 +224,7 @@ describe('ReportsPage', () => {
     renderPage()
 
     // Push entry: donations tab -> donor-statement tab
-    await user.click(screen.getByText('Estado de cuenta del donante'))
+    await user.click(screen.getByText('Resumen donativos por donante'))
 
     const input = screen.getByPlaceholderText('Buscar donante…')
     await user.click(input)

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -109,7 +109,8 @@
     "page": "Página {{page}} de {{total}}",
     "previous": "Anterior",
     "next": "Siguiente",
-    "editLabel": "Editar donante {{name}}"
+    "editLabel": "Editar donante {{name}}",
+    "statementLabel": "Ver donaciones"
   },
   "expenses": {
     "title": "Gastos",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -110,7 +110,7 @@
     "previous": "Anterior",
     "next": "Siguiente",
     "editLabel": "Editar donante {{name}}",
-    "statementLabel": "Ver donaciones"
+    "statementLabel": "Ver donaciones de {{name}}"
   },
   "expenses": {
     "title": "Gastos",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -182,7 +182,7 @@
     "title": "Reportes",
     "donationSummary": "Resumen de donaciones",
     "expenseSummary": "Resumen de gastos",
-    "donorStatement": "Estado de cuenta del donante",
+    "donorStatement": "Resumen donativos por donante",
     "type": "Tipo",
     "category": "Categoría",
     "total": "Total",


### PR DESCRIPTION
## What

Adds a per-row action on **DonorsPage** that navigates to the existing reports **donor-statement** screen with the donor preselected:

```
/reports?tab=donor-statement&donorId=<id>
```

A bar-chart icon sits beside each row's edit link. Clicking it lands on the donor-statement tab with the donor's name in the picker and the current-month statement loaded — no new query/UI, it reuses the screen that already reads `tab` and `donorId` from the URL.

## Why

Lets treasurers jump straight from a donor in the list to that donor's date-range donations, instead of navigating to Reports and re-searching for the donor.

## Access control

The link is gated on `canViewReports(user)` — it only shows to users who can actually reach `/reports`. On the donors list that's **TREASURER**. This mirrors the sidebar's `visible: canViewReports` gating and prevents OPERATORs (who can see `/donors` but not `/reports`) from getting a link that bounces them to `/`.

## Accessibility

Each statement link has a per-donor accessible name ("Ver donaciones de {{name}}"), so screen readers can distinguish rows — consistent with the sibling edit link. Icon-only affordance, so no visible change.

## Tests

- `donors-page.test.tsx`: asserts each row's statement-link `href`; asserts OPERATORs see **no** statement link (gating).
- `reports-page.test.tsx`: new test asserting the donor's name is preselected in the picker from a deep link (previously only the statement data was asserted). Also updates stale assertions after the `reports.donorStatement` label rename.

## Follow-up

- #163 — decouple the hard-coded `/reports?tab=...&donorId=...` string from the reports URL param contract (low priority).
