### PR TITLE
fix(calendar): attach day button ref so keyboard navigation moves focus

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,5 +1,5 @@
 import { cva, type VariantProps } from 'class-variance-authority'
-import { type ButtonHTMLAttributes } from 'react'
+import { type ComponentProps } from 'react'
 
 import { cn } from '@/lib/utils'
 
@@ -45,8 +45,7 @@ function Button({
   variant = 'default',
   size = 'default',
   ...props
-}: ButtonHTMLAttributes<HTMLButtonElement> &
-  VariantProps<typeof buttonVariants>) {
+}: ComponentProps<'button'> & VariantProps<typeof buttonVariants>) {
   return (
     <button
       data-slot="button"

--- a/src/components/ui/calendar.test.tsx
+++ b/src/components/ui/calendar.test.tsx
@@ -1,0 +1,78 @@
+import { render, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+import { Calendar } from './calendar'
+
+// January 2026 is fixed so the grid is deterministic:
+// 2026-01-14 is a Wednesday, its week runs Sun 2026-01-11 .. Sat 2026-01-17.
+const JANUARY_2026 = new Date(2026, 0, 1)
+const START = '2026-01-14'
+
+function renderCalendar() {
+  const { container } = render(
+    <Calendar mode="single" defaultMonth={JANUARY_2026} />
+  )
+
+  // react-day-picker sets data-day="yyyy-MM-dd" on the gridcell.
+  function dayButton(isoDate: string): HTMLButtonElement {
+    const button = container.querySelector<HTMLButtonElement>(
+      `[data-day="${isoDate}"] button`
+    )
+    if (!button) throw new Error(`No day button rendered for ${isoDate}`)
+    return button
+  }
+
+  return { container, dayButton }
+}
+
+describe('Calendar keyboard navigation', () => {
+  it('does not steal focus on mount', () => {
+    renderCalendar()
+    expect(document.body).toHaveFocus()
+  })
+
+  it.each([
+    ['{ArrowRight}', '2026-01-15'],
+    ['{ArrowLeft}', '2026-01-13'],
+    ['{ArrowDown}', '2026-01-21'],
+    ['{ArrowUp}', '2026-01-07'],
+    ['{Home}', '2026-01-11'],
+    ['{End}', '2026-01-17'],
+  ])('moves DOM focus to %s -> %s', async (key, expected) => {
+    const user = userEvent.setup()
+    const { dayButton } = renderCalendar()
+
+    dayButton(START).focus()
+    await user.keyboard(key)
+
+    expect(dayButton(expected)).toHaveFocus()
+  })
+
+  it.each([
+    ['{PageUp}', '2025-12-14'],
+    ['{PageDown}', '2026-02-14'],
+  ])('navigates months with %s and focuses %s', async (key, expected) => {
+    const user = userEvent.setup()
+    const { dayButton } = renderCalendar()
+
+    dayButton(START).focus()
+    await user.keyboard(key)
+
+    await waitFor(() => {
+      expect(dayButton(expected)).toHaveFocus()
+    })
+  })
+
+  it('moves the focused gridcell marker along with DOM focus', async () => {
+    const user = userEvent.setup()
+    const { dayButton } = renderCalendar()
+
+    dayButton(START).focus()
+    await user.keyboard('{ArrowRight}')
+
+    const moved = dayButton('2026-01-15')
+    expect(moved).toHaveFocus()
+    expect(moved.closest('td')).toHaveAttribute('data-focused', 'true')
+    expect(dayButton(START).closest('td')).not.toHaveAttribute('data-focused')
+  })
+})

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -202,6 +202,7 @@ function CalendarDayButton({
 
   return (
     <Button
+      ref={ref}
       variant="ghost"
       size="icon"
       data-day={day.date.toLocaleDateString(locale?.code)}


### PR DESCRIPTION
## Problem

`CalendarDayButton` created a ref and called `ref.current?.focus()` when a day became focused, but never attached it to the rendered `<Button>`. `ref.current` was permanently `null`, so the focus call was a no-op on every render.

I confirmed in `node_modules/react-day-picker/dist/esm/useFocus.js` that `moveFocus` only calls `calendar.goToDay()` and `setFocused()` — **react-day-picker never calls `.focus()` on a DOM node itself**. It sets `tabIndex` / `data-focused` and delegates the real focus call to the custom `DayButton`. That was exactly the dead call, so arrow keys moved the visual ring while DOM focus stayed behind: the roving-tabindex contract was broken and screen readers never announced the focused day.

This also rules out the issue's third option (drop the ref and let rdp handle focus) — rdp does not handle it.

Affected every `Calendar` consumer via `DateRangePicker`: dashboard, donations, expenses, and all three reports tabs.

## Changes

- **`button.tsx`** — props widened from `ButtonHTMLAttributes<HTMLButtonElement>` to `ComponentProps<'button'>` so `ref` typechecks. A pure widening (superset), so none of the ~34 existing call sites are affected. It already worked at runtime under React 19 — `{...props}` forwards `ref` to the DOM `<button>`.
- **`calendar.tsx`** — added `ref={ref}` to the `<Button>`. `DayPicker.js:318-322` passes no `ref` to `components.DayButton`, so no merged-ref helper is needed.
- **`calendar.test.tsx`** (new) — 10 tests over a fixed January 2026 grid.
- 
## Relates

- Closes #166

## Test evidence

The test earned its keep: before the fix **9 of 10 failed**, with focus stuck on Jan 14 while the target button sat at `tabindex="-1"`. After the fix, 10/10 pass.

Covers, asserting real `document.activeElement`:
- `ArrowLeft` / `ArrowRight` / `ArrowUp` / `ArrowDown`
- `Home` / `End` (start/end of week)
- `PageUp` / `PageDown` (month navigation)
- the `data-focused` gridcell marker tracks DOM focus
- mounting does not steal focus (no `autoFocus` → `focused` stays undefined)
