### PR TITLE
perf(dashboard): eliminate measured layout shifts and redundant refetches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 
 # testing
 /coverage
+/.lighthouse
 
 # production
 /build

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "chrome-devtools": {
+      "command": "npx",
+      "args": ["-y", "chrome-devtools-mcp@1.6.0", "--isolated"]
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "check:ci": "biome check src/",
     "dev": "vite",
     "lint": "biome lint --write src/",
+    "lighthouse": "mkdir -p .lighthouse && npx -y lighthouse@13 http://localhost:4173 --preset=desktop --output=json --output=html --output-path=./.lighthouse/report --chrome-flags=--headless",
     "preview": "vite preview",
     "start": "vite",
     "test": "vitest run",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ const queryClient = new QueryClient({
     queries: {
       retry: false,
       refetchOnWindowFocus: false,
+      staleTime: 30_000,
     },
   },
 })

--- a/src/components/ui/calendar.test.tsx
+++ b/src/components/ui/calendar.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor } from '@testing-library/react'
+import { act, render, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it } from 'vitest'
 import { Calendar } from './calendar'
@@ -22,7 +22,13 @@ function renderCalendar() {
     return button
   }
 
-  return { container, dayButton }
+  // DayPicker tracks the focused day in state, so a bare .focus() updates it
+  // outside React's knowledge and warns. act() flushes that update.
+  function focusDay(isoDate: string) {
+    act(() => dayButton(isoDate).focus())
+  }
+
+  return { container, dayButton, focusDay }
 }
 
 describe('Calendar keyboard navigation', () => {
@@ -40,9 +46,9 @@ describe('Calendar keyboard navigation', () => {
     ['{End}', '2026-01-17'],
   ])('moves DOM focus to %s -> %s', async (key, expected) => {
     const user = userEvent.setup()
-    const { dayButton } = renderCalendar()
+    const { dayButton, focusDay } = renderCalendar()
 
-    dayButton(START).focus()
+    focusDay(START)
     await user.keyboard(key)
 
     expect(dayButton(expected)).toHaveFocus()
@@ -53,9 +59,9 @@ describe('Calendar keyboard navigation', () => {
     ['{PageDown}', '2026-02-14'],
   ])('navigates months with %s and focuses %s', async (key, expected) => {
     const user = userEvent.setup()
-    const { dayButton } = renderCalendar()
+    const { dayButton, focusDay } = renderCalendar()
 
-    dayButton(START).focus()
+    focusDay(START)
     await user.keyboard(key)
 
     await waitFor(() => {
@@ -65,9 +71,9 @@ describe('Calendar keyboard navigation', () => {
 
   it('moves the focused gridcell marker along with DOM focus', async () => {
     const user = userEvent.setup()
-    const { dayButton } = renderCalendar()
+    const { dayButton, focusDay } = renderCalendar()
 
-    dayButton(START).focus()
+    focusDay(START)
     await user.keyboard('{ArrowRight}')
 
     const moved = dayButton('2026-01-15')

--- a/src/features/dashboard/financial-overview.test.tsx
+++ b/src/features/dashboard/financial-overview.test.tsx
@@ -20,6 +20,22 @@ describe('FinancialOverview', () => {
     expect(screen.getByText(/2[.\s]?000/)).toBeInTheDocument()
   })
 
+  it('renders the stat cards while loading rather than a skeleton above them', async () => {
+    renderWithProviders(<FinancialOverview />)
+
+    // The cards are in the tree from the first paint, showing placeholders.
+    expect(screen.getByText('Ingresos totales')).toBeInTheDocument()
+    expect(screen.getAllByText('—')).toHaveLength(3)
+
+    // So no extra loading block sits above them: one that unmounts on load
+    // would pull the whole dashboard upwards and shift the layout.
+    expect(screen.queryByLabelText('Cargando...')).not.toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(screen.getByText(/5[.\s]?000/)).toBeInTheDocument()
+    })
+  })
+
   it('renders card titles', () => {
     renderWithProviders(<FinancialOverview />)
 

--- a/src/features/dashboard/financial-overview.test.tsx
+++ b/src/features/dashboard/financial-overview.test.tsx
@@ -36,6 +36,18 @@ describe('FinancialOverview', () => {
     })
   })
 
+  it('reserves a stable height on both chart cards', () => {
+    const { container } = renderWithProviders(<FinancialOverview />)
+
+    // The empty state is shorter than a rendered chart, so without a floor
+    // the cards grow when a range with data is picked. 300px covers the
+    // tallest chart box (max-h-75) in either card.
+    const contents = container.querySelectorAll(
+      '[data-slot="card-content"].min-h-75'
+    )
+    expect(contents).toHaveLength(2)
+  })
+
   it('renders card titles', () => {
     renderWithProviders(<FinancialOverview />)
 

--- a/src/features/dashboard/financial-overview.tsx
+++ b/src/features/dashboard/financial-overview.tsx
@@ -3,7 +3,6 @@ import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { DateRangePicker } from '@/components/date-range-picker'
 import { EmptyState } from '@/components/empty-state'
-import { Skeleton } from '@/components/skeleton'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import type { ChartConfig } from '@/components/ui/chart'
@@ -102,13 +101,7 @@ export function FinancialOverview() {
         </Alert>
       )}
 
-      {isLoading && (
-        <div aria-busy="true" aria-label={t('common.loading')}>
-          <Skeleton />
-        </div>
-      )}
-
-      <div className="grid gap-4 sm:grid-cols-3">
+      <div className="grid gap-4 sm:grid-cols-3" aria-busy={isLoading}>
         <StatCard
           label={t('dashboard.totalIncome')}
           icon={<ArrowUpRight size={16} className="text-success" />}

--- a/src/features/dashboard/financial-overview.tsx
+++ b/src/features/dashboard/financial-overview.tsx
@@ -131,7 +131,7 @@ export function FinancialOverview() {
           <CardHeader>
             <CardTitle>{t('dashboard.donationsByType')}</CardTitle>
           </CardHeader>
-          <CardContent>
+          <CardContent className="min-h-75">
             {titheData.length > 0 || otherDonationsData.length > 0 ? (
               <div className="space-y-4">
                 {titheData.length > 0 && (
@@ -167,7 +167,7 @@ export function FinancialOverview() {
           <CardHeader>
             <CardTitle>{t('dashboard.expensesByCategory')}</CardTitle>
           </CardHeader>
-          <CardContent>
+          <CardContent className="min-h-75">
             {expenseChartData.length > 0 ? (
               <ComparisonBarChart
                 data={expenseChartData}

--- a/src/features/dashboard/stat-card.test.tsx
+++ b/src/features/dashboard/stat-card.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { StatCard } from './stat-card'
+
+function renderCard(props: Partial<Parameters<typeof StatCard>[0]> = {}) {
+  return render(
+    <StatCard
+      label="Ingresos totales"
+      icon={<span />}
+      value={5000}
+      current={5000}
+      previous={4000}
+      {...props}
+    />
+  )
+}
+
+describe('StatCard', () => {
+  it('renders the percentage change when previous period data is present', () => {
+    renderCard()
+    expect(screen.getByText(/25\.0%/)).toBeInTheDocument()
+  })
+
+  it('reserves the change line while previous period data is missing', () => {
+    const { container } = renderCard({ previous: undefined })
+
+    // No figure to show yet...
+    expect(screen.queryByText(/%/)).not.toBeInTheDocument()
+
+    // ...but the line still occupies its space, so the card does not grow
+    // when the slower previous-period query resolves.
+    const placeholder = container.querySelector('[data-slot="pct-change"]')
+    expect(placeholder).toBeInTheDocument()
+    expect(placeholder).toHaveClass('invisible')
+  })
+
+  it('renders a placeholder instead of a value while loading', () => {
+    renderCard({ value: undefined })
+    expect(screen.getByText('—')).toBeInTheDocument()
+  })
+})

--- a/src/features/dashboard/stat-card.tsx
+++ b/src/features/dashboard/stat-card.tsx
@@ -13,11 +13,23 @@ function PctChange({
   inverted?: boolean
 }) {
   const pct = calcPctChange(current, previous)
-  if (pct == null) return null
+  // The previous-period queries resolve independently of the current-period
+  // ones, so hold the line's space until they land or the card grows a row.
+  if (pct == null)
+    return (
+      <span
+        data-slot="pct-change"
+        aria-hidden="true"
+        className="invisible mt-1 text-xs font-medium"
+      >
+        &nbsp;
+      </span>
+    )
   const isPositive = pct > 0
   const isGood = inverted ? !isPositive : isPositive
   return (
     <span
+      data-slot="pct-change"
       className={`mt-1 text-xs font-medium ${isGood ? 'text-success' : 'text-destructive'}`}
     >
       {isPositive ? '↑' : '↓'} {Math.abs(pct).toFixed(1)}%

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,9 +3,22 @@ import babel from '@rolldown/plugin-babel'
 import tailwindcss from '@tailwindcss/vite'
 import react, { reactCompilerPreset } from '@vitejs/plugin-react'
 import { visualizer } from 'rollup-plugin-visualizer'
-import { defineConfig } from 'vite'
+import { defineConfig, type ProxyOptions } from 'vite'
 
 const PORT = 3000
+// Shared by dev and preview so a production build can be measured against the
+// local API. Without it `vite preview` has no /api and only /login is reachable.
+const apiProxy: Record<string, ProxyOptions> = {
+  '/api': {
+    target: 'http://localhost:8081',
+    changeOrigin: true,
+    configure: (proxy) => {
+      proxy.on('proxyReq', (proxyReq) => {
+        proxyReq.removeHeader('origin')
+      })
+    },
+  },
+}
 // Just above the recharts chart chunk, which is the largest chunk we can't
 // shrink without replacing the library. Low enough to catch real growth,
 // reachable enough that a green build still means something.
@@ -48,16 +61,9 @@ export default defineConfig({
   },
   server: {
     port: PORT,
-    proxy: {
-      '/api': {
-        target: 'http://localhost:8081',
-        changeOrigin: true,
-        configure: (proxy) => {
-          proxy.on('proxyReq', (proxyReq) => {
-            proxyReq.removeHeader('origin')
-          })
-        },
-      },
-    },
+    proxy: apiProxy,
+  },
+  preview: {
+    proxy: apiProxy,
   },
 })


### PR DESCRIPTION
Fixes every layout shift measured on the dashboard, plus a query-cache setting that made each navigation refetch data seconds old. All numbers below are measured — on the live production deployment where noted, otherwise on a local trace.

## Impact

| | Before | After |
|---|---|---|
| Dashboard cold-load CLS | 0.0249 | **0.00** |
| Range-change CLS | 0.0505 | **0** |
| Dashboard CLS on production mobile (Slow 4G, 4× CPU) | 0.0543 | expected ~0 |
| Requests on `/` → `/donations` → `/` | full six-query fan-out | **zero** |

## What's here

**`perf(query): set default staleTime to 30s`** — queries were stale on arrival, so since every route is lazy and unmounts on navigation, returning to the dashboard refired all six report queries for data seconds old. Verified by trace: a round trip inside the window now fires nothing. Mutations already invalidate their own keys, so same-tab writes stay correct.

**`fix(dashboard): stop the loading skeleton shifting the layout 56px`** — the skeleton rendered *in addition to* the stat grid rather than instead of it. Per-frame DOM sampling caught the grid top moving 242px → 186px when it unmounted, pulling everything below up by 56px (40px skeleton + 16px gap). `StatCard` already renders a placeholder at identical height, so it was redundant. Loading state now rides on `aria-busy` on the grid — the original `aria-busy`/`aria-label` affordance is preserved rather than dropped for the metric.

**`fix(dashboard): reserve the percentage-change line in StatCard`** — `isLoading` deliberately excludes the three previous-period queries so cards paint as soon as current-period data lands; `PctChange` then mounted a span that grew every card. **Not reproducible against a local API**, where all six resolve together — fixed as a latent issue on slow networks, not an observed one. Reserving the line beats delaying first paint on data nobody is blocked on.

**`fix(dashboard): reserve chart card height so the empty state cannot shift it`** — `CardContent` had no height floor. `min-h-75` matches the tallest chart box (`max-h-75`), and `CardContent` has zero vertical padding with `border-box`, so the content area is identical whether it holds charts, an empty state, or nothing yet. **Production measurement showed this is ~85% of dashboard CLS** — and that the shift fires on an *empty* range, so the floor protects against the empty state rendering after loading, not just against data arriving.

**`build(vite): proxy /api in preview as well as dev`** — `vite preview` ignores `server.proxy`, so the production build had no `/api` and Lighthouse could only ever reach `/login`. Sharing one config between both makes production CWV measurable on authenticated routes.

**`chore(perf): add chrome-devtools MCP and lighthouse script`** — tooling that produced the numbers above. `pnpm run lighthouse` needs `pnpm run preview` running; output is gitignored.

## Tradeoffs

- **An empty dashboard is ~96px taller per card.** Accepted deliberately: a stable box in both states is worth the extra height.
- `.mcp.json` is committed, so it applies to anyone opening the repo in Claude Code. Happy to drop it to a local-only config if you'd rather not have it in the tree.
- The Lighthouse script uses `npx -y lighthouse@13` rather than a devDependency, to avoid ~100 MB in `node_modules` for something run occasionally. Pin it if it should be reproducible in CI.

## Related

- Closes part of #172.


## Not included

- **Calendar forced reflow** (`src/components/ui/calendar.tsx:199`) — ~70 per-day `.focus()` effects, 47 ms forced layout. The behaviour is a keyboard-navigation a11y requirement from cde0184, and the 280 ms INP driving it is a dev-server number at 4× throttle. Needs a production INP before trading against accessibility.
- **Two infrastructure fixes that outrank everything here** and aren't code: production HTML ships with no `Cache-Control` (stale shell can white-screen users after a deploy), and compression is running at gzip level 1. Both detailed in [#172](https://github.com/jorgetroya80/donations-frontend/issues/172#issuecomment-5151398313).


## Two findings this PR deliberately does *not* act on

Both were investigated and **refuted by measurement** — documented so they don't get re-raised:

- **The recharts namespace import is fine.** Built both ways: 37 bytes gzip apart. Rolldown tree-shakes namespace member access.
- **The Geist font causes no CLS.** Attributed shift 0.0000; `/login` CLS is 0.
