### PR TITLE
perf: cache HTML, compress properly, and split the calendar chunk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ LABEL org.opencontainers.image.title="donations-frontend" \
       org.opencontainers.image.source="https://github.com/jorgetroya80/donations-frontend"
 
 COPY default.conf.template /etc/nginx/templates/default.conf.template
+COPY security-headers.conf /etc/nginx/security-headers.conf
 COPY --from=build /app/dist /usr/share/nginx/html
 
 ENV PORT=80 API_UPSTREAM=http://api:8081 API_HOST=api

--- a/default.conf.template
+++ b/default.conf.template
@@ -15,11 +15,7 @@ server {
     # level 9) instead of compressing the same immutable bytes per request.
     gzip_static on;
 
-    add_header X-Frame-Options "SAMEORIGIN" always;
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header X-XSS-Protection "1; mode=block" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'" always;
+    include /etc/nginx/security-headers.conf;
 
     location /api/ {
         proxy_pass ${API_UPSTREAM};
@@ -41,14 +37,7 @@ server {
         # no-cache means "revalidate", not "don't store" - no-store would kill
         # bfcache. Revalidation is a 304 in the normal case.
         add_header Cache-Control "no-cache" always;
-
-        # nginx add_header does not merge across levels: declaring one here
-        # drops every header set on the server block, so they are repeated.
-        add_header X-Frame-Options "SAMEORIGIN" always;
-        add_header X-Content-Type-Options "nosniff" always;
-        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-        add_header X-XSS-Protection "1; mode=block" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'" always;
+        include /etc/nginx/security-headers.conf;
     }
 
     location ~* \.(?:css|js|svg|png|jpg|jpeg|gif|ico|woff2?)$ {

--- a/default.conf.template
+++ b/default.conf.template
@@ -4,9 +4,16 @@ server {
     index index.html;
 
     gzip on;
-    gzip_types text/plain text/css application/javascript application/json image/svg+xml;
+    # nginx defaults gzip_comp_level to 1; production was measured serving the
+    # entry chunk at 167,853 B, within 7 bytes of `gzip -1`. Level 6 is the
+    # usual size/CPU knee.
+    gzip_comp_level 6;
+    gzip_types text/plain text/css text/javascript application/javascript application/json application/xml application/wasm image/svg+xml font/woff2;
     gzip_min_length 1024;
     gzip_vary on;
+    # Serve the .gz files the build writes next to each asset (compressed at
+    # level 9) instead of compressing the same immutable bytes per request.
+    gzip_static on;
 
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;
@@ -26,6 +33,22 @@ server {
 
     location / {
         try_files $uri $uri/ /index.html;
+
+        # index.html references content-hashed assets, so a cached copy that
+        # outlives a deploy points at files the origin no longer has: a blank
+        # page, not a slow one. Without this header browsers apply heuristic
+        # freshness (~10% of document age) and never revalidate.
+        # no-cache means "revalidate", not "don't store" - no-store would kill
+        # bfcache. Revalidation is a 304 in the normal case.
+        add_header Cache-Control "no-cache" always;
+
+        # nginx add_header does not merge across levels: declaring one here
+        # drops every header set on the server block, so they are repeated.
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header X-XSS-Protection "1; mode=block" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'" always;
     }
 
     location ~* \.(?:css|js|svg|png|jpg|jpeg|gif|ico|woff2?)$ {

--- a/docs/plans/web-perf-followup-todo.md
+++ b/docs/plans/web-perf-followup-todo.md
@@ -7,21 +7,21 @@ Each task is a vertical slice: it changes something, and it ends with a number o
 
 ## Phase 1 — nginx caching + compression (`perf(nginx):`)
 
-- [ ] **1.1 `Cache-Control: no-cache` on the HTML entry point** — `default.conf.template`.
+- [x] **1.1 `Cache-Control: no-cache` on the HTML entry point** — `default.conf.template`.
       Accept: `curl -sI /` and `curl -sI /donations` both return `cache-control: no-cache`.
       Accept: hashed assets keep `public, immutable, max-age=31536000`.
       Accept: the five security headers (CSP, X-Frame-Options, X-Content-Type-Options,
       Referrer-Policy, X-XSS-Protection) still present on the HTML response — `add_header`
       does not merge across nginx levels, so a new block silently drops them.
-- [ ] **1.2 Raise gzip level and widen the type list** — `default.conf.template`:
+- [x] **1.2 Raise gzip level and widen the type list** — `default.conf.template`:
       `gzip_comp_level 6`, add `text/javascript`, `font/woff2`, `application/wasm`.
       Accept: served size of the entry chunk matches `gzip -9`/`gzip -6`, not `gzip -1`.
       Baseline to beat: 167,853 B served vs 142,495 B at `gzip -9` (raw 449,635 B).
-- [ ] **1.3 Precompress assets at build time** — inline `writeBundle` plugin in `vite.config.ts`
+- [x] **1.3 Precompress assets at build time** — inline `writeBundle` plugin in `vite.config.ts`
       using `node:zlib` at level 9, plus `gzip_static on` in nginx. No new dependency.
       Accept: `dist/assets/*.js.gz` exist after `pnpm run build`; nginx serves them
       (byte-identical to the local `.gz`, zero per-request CPU).
-- [ ] **1.4 Checkpoint — measure in Docker before opening the PR.**
+- [x] **1.4 Checkpoint — measure in Docker before opening the PR.**
       `pnpm run build && docker build -t df-perf . && docker run --rm -p 8081:80 -e PORT=80 df-perf`
       Record before/after bytes for the entry chunk in the PR description.
 - [ ] **1.5 Flag Cloudflare Brotli to Jorge** — dashboard toggle, not a repo change (~57 KB,
@@ -33,22 +33,22 @@ Each task is a vertical slice: it changes something, and it ends with a number o
 
 ## Phase 2 — lazy-load the calendar (`perf(calendar):`)
 
-- [ ] **2.1 Grep every `Calendar` import site** before touching anything. Only
+- [x] **2.1 Grep every `Calendar` import site** before touching anything. Only
       `src/components/date-range-picker.tsx` is in scope; leave other call sites alone.
 - [ ] **2.2 Measure the real popover box** — open the two-month calendar and read its
       rendered dimensions from the DOM. The Suspense fallback is sized from this number,
       not guessed.
-- [ ] **2.3 New `src/components/ui/calendar.lazy.tsx`** — mirror
+- [x] **2.3 New `src/components/ui/calendar.lazy.tsx`** — mirror
       `src/features/dashboard/comparison-bar-chart.lazy.tsx`: same exported component name,
       `type`-only props import, local `Suspense` with a box-matched fallback.
-- [ ] **2.4 Point `date-range-picker.tsx` at the lazy wrapper.** Trigger button stays eager.
+- [x] **2.4 Point `date-range-picker.tsx` at the lazy wrapper.** Trigger button stays eager.
       `dayjs` stays eager — the trigger label needs it.
-- [ ] **2.5 Prefetch on `onMouseEnter`/`onFocus`** of the trigger so the chunk is usually
+- [x] **2.5 Prefetch on `onMouseEnter`/`onFocus`** of the trigger so the chunk is usually
       resident before the popover opens.
-- [ ] **2.6 Checkpoint.** `pnpm run test` green, including all 10 keyboard-nav tests in
+- [x] **2.6 Checkpoint.** `pnpm run test` green, including all 10 keyboard-nav tests in
       `src/components/ui/calendar.test.tsx` — if the lazy boundary breaks them the wrapper
       is wrong; do not weaken the tests. Then `pnpm run typecheck`, `pnpm run check:ci`.
-- [ ] **2.7 Confirm the bundle actually moved** — `pnpm run analyze`; `date-range-picker-*.js`
+- [x] **2.7 Confirm the bundle actually moved** — `pnpm run analyze`; `date-range-picker-*.js`
       (93.19 KB raw / 29.05 KB gzip) must leave the eager graph of `/`, `/donations`,
       `/expenses`, `/reports`.
 - [ ] **2.8 Browser check** — open the picker on `/` and `/donations`, pick a range, confirm
@@ -56,7 +56,7 @@ Each task is a vertical slice: it changes something, and it ends with a number o
 
 ## Phase 3 — font preload (`perf(fonts):`) — optional, revert if it does not pay
 
-- [ ] **3.1 Emit the preload tag from a Vite `transformIndexHtml` hook** reading the hashed
+- [x] **3.1 Emit the preload tag from a Vite `transformIndexHtml` hook** reading the hashed
       woff2 filename out of the bundle. Never hardcode the hash. `crossorigin` is required
       even same-origin, or the font double-fetches.
 - [ ] **3.2 Checkpoint** — production trace showing the font starting alongside the CSS
@@ -82,6 +82,22 @@ Each task is a vertical slice: it changes something, and it ends with a number o
 - [ ] Update #172 with measured results, including the won't-do decisions — the issue exists
       partly so refuted findings are not re-raised.
 - [ ] Delete the local `feat-exp-web-perf` branch (superseded by PR #173, released in 0.3.8).
+
+## Measured so far (branch `feat-web-perf-followup`)
+
+| What | Before | After |
+|---|---:|---:|
+| Entry chunk over the wire | 98,926 B (`gzip -1`) | 84,607 B (build-time `gzip -9`, served via `gzip_static`) |
+| `date-range-picker` chunk, eager | 93.19 kB / 29.06 kB gzip | 22.53 kB / 9.04 kB gzip |
+| Calendar (`react-day-picker`) | eager on 4 routes | 72.64 kB / 21.40 kB gzip, on demand |
+| Font request start (preview) | after CSS parse (387 ms in prod) | 12 ms, same burst as CSS and entry JS |
+| `/login` Lighthouse (preview, desktop) | 100 / LCP 0.6 s / CLS 0 | 100 / LCP 0.6 s / CLS 0 — no regression |
+
+nginx headers verified against `nginx:1.27-alpine` serving the real `dist`: `/` and
+`/donations` both return `cache-control: no-cache` plus all five security headers; assets
+keep `public, immutable` and are served as the build-time `.gz` byte for byte.
+
+Test suite: 401 passed (4 added), typecheck and Biome clean.
 
 ## Measurement caveats
 

--- a/docs/plans/web-perf-followup-todo.md
+++ b/docs/plans/web-perf-followup-todo.md
@@ -35,7 +35,7 @@ Each task is a vertical slice: it changes something, and it ends with a number o
 
 - [x] **2.1 Grep every `Calendar` import site** before touching anything. Only
       `src/components/date-range-picker.tsx` is in scope; leave other call sites alone.
-- [ ] **2.2 Measure the real popover box** — open the two-month calendar and read its
+- [x] **2.2 Measure the real popover box** — open the two-month calendar and read its
       rendered dimensions from the DOM. The Suspense fallback is sized from this number,
       not guessed.
 - [x] **2.3 New `src/components/ui/calendar.lazy.tsx`** — mirror
@@ -51,7 +51,7 @@ Each task is a vertical slice: it changes something, and it ends with a number o
 - [x] **2.7 Confirm the bundle actually moved** — `pnpm run analyze`; `date-range-picker-*.js`
       (93.19 KB raw / 29.05 KB gzip) must leave the eager graph of `/`, `/donations`,
       `/expenses`, `/reports`.
-- [ ] **2.8 Browser check** — open the picker on `/` and `/donations`, pick a range, confirm
+- [x] **2.8 Browser check** — open the picker on `/` and `/donations`, pick a range, confirm
       the query refires and the popover does not resize when the chunk lands.
 
 ## Phase 3 — font preload (`perf(fonts):`) — optional, revert if it does not pay
@@ -65,14 +65,14 @@ Each task is a vertical slice: it changes something, and it ends with a number o
 
 ## Phase 4 — measure, then decide
 
-- [ ] **4.1 Production INP on the date picker** — after Phase 2 lands, since it changes the
+- [x] **4.1 Production INP on the date picker** — after Phase 2 lands, since it changes the
       load path. Under 200 ms → close 4.2 unchanged.
-- [ ] **4.2 Calendar focus reflow** (`src/components/ui/calendar.tsx:198-201`) — only if 4.1
+- [x] **4.2 Calendar focus reflow** (`src/components/ui/calendar.tsx:198-201`) — only if 4.1
       says it is genuinely slow. The behaviour is an accessibility requirement (`cde0184`)
       and 9 of 10 tests fail without it.
-- [ ] **4.3 Sidebar prefetch** (`src/layouts/sidebar.tsx:114`) — measure a cold sidebar
+- [x] **4.3 Sidebar prefetch** (`src/layouts/sidebar.tsx:114`) — measure a cold sidebar
       navigation; act only if the chunk hop is a material share of the total.
-- [ ] **4.4 Lazy `AppLayout`** — recommend closing as won't-do. It introduces a waterfall for
+- [x] **4.4 Lazy `AppLayout`** — recommend closing as won't-do. It introduces a waterfall for
       already-authenticated arrivals and recovers well under the 35 KB first estimated.
 - [ ] **4.5 Open a separate issue for a `web-vitals` field beacon.** CrUX has nothing for this
       origin; every number in #172 is lab data.
@@ -98,6 +98,34 @@ nginx headers verified against `nginx:1.27-alpine` serving the real `dist`: `/` 
 keep `public, immutable` and are served as the build-time `.gz` byte for byte.
 
 Test suite: 401 passed (4 added), typecheck and Biome clean.
+
+### Authenticated session, production build on `vite preview`
+
+Measured against the local API with a real login, unthrottled desktop.
+
+| Check | Result |
+|---|---|
+| Popover box, fallback vs calendar | 604 px → 569 px. Shrinks by one week row, never grows. |
+| Calendar chunk on trigger hover | fetched on `mouseover`, 5 ms; one frame of fallback still shows because React's `lazy` awaits its own promise |
+| Range change on `/` | six-query fan-out refires with the new dates, **CLS 0** |
+| Range change on `/donations` | applies to the list, no shift |
+| **INP, opening the picker** | **40 ms**, zero long tasks |
+| **INP, clicking a day** | **48 ms**, zero long tasks |
+| Cold sidebar nav to `/expenses` | chunk starts +0 ms, API fires +7 ms — the serialization is real but 7 ms locally |
+| Dashboard load | CLS 0, no shifts recorded |
+
+**4.1/4.2 decision — close, change nothing.** The audit's 280 ms came from the dev server at
+4× CPU throttle. A production build measures 40–48 ms with no long task, so the ~70 focus
+effects are not worth touching accessibility-critical code for. Caveat: unthrottled desktop;
+even at 4× this stays around 200 ms, and the `cde0184` focus behaviour is required by 9 of
+the 10 keyboard tests.
+
+**4.3 decision — defer.** The chunk → mount → query ordering is confirmed, but locally it
+costs 7 ms. On a real network hover prefetch would save roughly one RTT for a small chunk.
+Not worth coupling the sidebar to route module paths until a production number says otherwise.
+
+**4.4 decision — won't do**, per the audit's own reasoning: it introduces a waterfall for
+already-authenticated arrivals and recovers well under the 35 KB first estimated.
 
 ## Measurement caveats
 

--- a/docs/plans/web-perf-followup-todo.md
+++ b/docs/plans/web-perf-followup-todo.md
@@ -1,0 +1,91 @@
+# Web performance follow-up — task list
+
+Companion checklist for [web-perf-followup.md](./web-perf-followup.md). Tracks issue
+[#172](https://github.com/jorgetroya80/donations-frontend/issues/172).
+
+Each task is a vertical slice: it changes something, and it ends with a number or a passing check.
+
+## Phase 1 — nginx caching + compression (`perf(nginx):`)
+
+- [ ] **1.1 `Cache-Control: no-cache` on the HTML entry point** — `default.conf.template`.
+      Accept: `curl -sI /` and `curl -sI /donations` both return `cache-control: no-cache`.
+      Accept: hashed assets keep `public, immutable, max-age=31536000`.
+      Accept: the five security headers (CSP, X-Frame-Options, X-Content-Type-Options,
+      Referrer-Policy, X-XSS-Protection) still present on the HTML response — `add_header`
+      does not merge across nginx levels, so a new block silently drops them.
+- [ ] **1.2 Raise gzip level and widen the type list** — `default.conf.template`:
+      `gzip_comp_level 6`, add `text/javascript`, `font/woff2`, `application/wasm`.
+      Accept: served size of the entry chunk matches `gzip -9`/`gzip -6`, not `gzip -1`.
+      Baseline to beat: 167,853 B served vs 142,495 B at `gzip -9` (raw 449,635 B).
+- [ ] **1.3 Precompress assets at build time** — inline `writeBundle` plugin in `vite.config.ts`
+      using `node:zlib` at level 9, plus `gzip_static on` in nginx. No new dependency.
+      Accept: `dist/assets/*.js.gz` exist after `pnpm run build`; nginx serves them
+      (byte-identical to the local `.gz`, zero per-request CPU).
+- [ ] **1.4 Checkpoint — measure in Docker before opening the PR.**
+      `pnpm run build && docker build -t df-perf . && docker run --rm -p 8081:80 -e PORT=80 df-perf`
+      Record before/after bytes for the entry chunk in the PR description.
+- [ ] **1.5 Flag Cloudflare Brotli to Jorge** — dashboard toggle, not a repo change (~57 KB,
+      25% of the critical path). Origin Brotli is not viable: `nginx:1.27-alpine` has no
+      `ngx_brotli`. After enabling, re-check whether the edge passes origin gzip through
+      or re-compresses.
+- [ ] **1.6 Verify in production after deploy** — repeat 1.1 and 1.2 against the live URL.
+      Render autodeploys from `main`.
+
+## Phase 2 — lazy-load the calendar (`perf(calendar):`)
+
+- [ ] **2.1 Grep every `Calendar` import site** before touching anything. Only
+      `src/components/date-range-picker.tsx` is in scope; leave other call sites alone.
+- [ ] **2.2 Measure the real popover box** — open the two-month calendar and read its
+      rendered dimensions from the DOM. The Suspense fallback is sized from this number,
+      not guessed.
+- [ ] **2.3 New `src/components/ui/calendar.lazy.tsx`** — mirror
+      `src/features/dashboard/comparison-bar-chart.lazy.tsx`: same exported component name,
+      `type`-only props import, local `Suspense` with a box-matched fallback.
+- [ ] **2.4 Point `date-range-picker.tsx` at the lazy wrapper.** Trigger button stays eager.
+      `dayjs` stays eager — the trigger label needs it.
+- [ ] **2.5 Prefetch on `onMouseEnter`/`onFocus`** of the trigger so the chunk is usually
+      resident before the popover opens.
+- [ ] **2.6 Checkpoint.** `pnpm run test` green, including all 10 keyboard-nav tests in
+      `src/components/ui/calendar.test.tsx` — if the lazy boundary breaks them the wrapper
+      is wrong; do not weaken the tests. Then `pnpm run typecheck`, `pnpm run check:ci`.
+- [ ] **2.7 Confirm the bundle actually moved** — `pnpm run analyze`; `date-range-picker-*.js`
+      (93.19 KB raw / 29.05 KB gzip) must leave the eager graph of `/`, `/donations`,
+      `/expenses`, `/reports`.
+- [ ] **2.8 Browser check** — open the picker on `/` and `/donations`, pick a range, confirm
+      the query refires and the popover does not resize when the chunk lands.
+
+## Phase 3 — font preload (`perf(fonts):`) — optional, revert if it does not pay
+
+- [ ] **3.1 Emit the preload tag from a Vite `transformIndexHtml` hook** reading the hashed
+      woff2 filename out of the bundle. Never hardcode the hash. `crossorigin` is required
+      even same-origin, or the font double-fetches.
+- [ ] **3.2 Checkpoint** — production trace showing the font starting alongside the CSS
+      instead of after it (was: 390 ms, third hop).
+      **Under ~100 ms improvement → revert.** Not a CLS source; that stays refuted.
+
+## Phase 4 — measure, then decide
+
+- [ ] **4.1 Production INP on the date picker** — after Phase 2 lands, since it changes the
+      load path. Under 200 ms → close 4.2 unchanged.
+- [ ] **4.2 Calendar focus reflow** (`src/components/ui/calendar.tsx:198-201`) — only if 4.1
+      says it is genuinely slow. The behaviour is an accessibility requirement (`cde0184`)
+      and 9 of 10 tests fail without it.
+- [ ] **4.3 Sidebar prefetch** (`src/layouts/sidebar.tsx:114`) — measure a cold sidebar
+      navigation; act only if the chunk hop is a material share of the total.
+- [ ] **4.4 Lazy `AppLayout`** — recommend closing as won't-do. It introduces a waterfall for
+      already-authenticated arrivals and recovers well under the 35 KB first estimated.
+- [ ] **4.5 Open a separate issue for a `web-vitals` field beacon.** CrUX has nothing for this
+      origin; every number in #172 is lab data.
+
+## Closing out
+
+- [ ] Update #172 with measured results, including the won't-do decisions — the issue exists
+      partly so refuted findings are not re-raised.
+- [ ] Delete the local `feat-exp-web-perf` branch (superseded by PR #173, released in 0.3.8).
+
+## Measurement caveats
+
+- `:4173` needs a manual login first — the session token is origin-scoped to `:3000`.
+- Do not measure against real production donation records. Seed a staging instance with fake
+  data, and use a **populated** date range: the last dashboard figures came from an empty
+  August 2026 range.

--- a/docs/plans/web-perf-followup.md
+++ b/docs/plans/web-perf-followup.md
@@ -1,0 +1,181 @@
+# Web performance follow-up (issue #172)
+
+## Context
+
+Issue [#172](https://github.com/jorgetroya80/donations-frontend/issues/172) records a web performance audit run twice: once on localhost, once against the live Render deployment. It documents what was fixed, what was **refuted** (recharts namespace import, font-caused CLS — do not re-raise either), and what remains open.
+
+Since the issue was written, its priority 3 ("deploy the branch") has already landed: PR #173 (`60a3de5`) merged every dashboard fix — `staleTime: 30_000`, skeleton removal, `PctChange` reservation, chart-card `min-h-75`, the preview proxy — and released as 0.3.8. Production autodeploys from `main`, so the 0.0543 → ~0.008 dashboard CLS win is already live. The local `feat-exp-web-perf` branch is now redundant and should be deleted.
+
+What remains is everything the audit ranked **above** that deployment plus the deferred code items:
+
+1. **HTML ships with no `Cache-Control`** — a stale `index.html` referencing content-hashed assets that no longer exist white-screens users after a deploy. Failure mode, not a slowdown.
+2. **Compression runs at gzip level 1** — production bytes match `gzip -1` to within 7 bytes. `gzip -9` alone saves 25.4 KB (15.1%) on the entry chunk; ~57 KB (25%) across the critical path with Brotli.
+3. **The date-range picker is 93 KB raw / 29 KB gzip loaded eagerly** on four routes for a calendar that only renders when a popover opens.
+4. Font preload, calendar INP, and sidebar prefetch — all gated in the issue on measurement that has not been taken.
+
+The audit named the origin of items 1 and 2 as "infrastructure, not code, neither lives in this repo." That is wrong: `default.conf.template` **is** in this repo, and it has `gzip on` with no `gzip_comp_level` — nginx's default is 1, which exactly explains the measured bytes. Both are fixable here.
+
+**Outcome**: remove the white-screen-after-deploy failure mode, cut 15–25% off the critical path, defer the largest remaining JS payload, and close #172 with every open item either done or explicitly decided with a number behind it.
+
+## Files
+
+| File                                   | Change                                                                           |
+| -------------------------------------- | -------------------------------------------------------------------------------- |
+| `default.conf.template`                | `Cache-Control` on HTML, `gzip_comp_level`, `gzip_types`, `gzip_static`          |
+| `vite.config.ts`                       | build-time gzip precompression plugin; font preload tag                          |
+| `src/components/date-range-picker.tsx` | lazy popover content                                                             |
+| `src/components/ui/calendar.lazy.tsx`  | **new** — mirrors `src/features/dashboard/comparison-bar-chart.lazy.tsx`         |
+| `index.html`                           | font preload target (via a Vite `transformIndexHtml` hook, not a hardcoded hash) |
+
+---
+
+## Phase 1 — nginx: caching + compression
+
+**Both changes are in `default.conf.template`.** No app code.
+
+### 1a. `Cache-Control: no-cache` on HTML
+
+`location /` currently serves `index.html` via `try_files` with no `Cache-Control` at all. Per RFC 9111 browsers then apply heuristic freshness (~10% of document age); production's `last-modified` was 13 days old at audit time, giving ~1.3 days of caching with zero revalidation. Add an exact-match location:
+
+```nginx
+location = /index.html {
+    add_header Cache-Control "no-cache" always;
+}
+```
+
+`no-cache` (revalidate every time), **not** `no-store` — `no-store` would break bfcache, which the audit confirmed is currently preserved. Cost is one conditional request per navigation, ~54 ms at the measured TTFB, almost always a 304.
+
+Note `location = /index.html` does not catch `try_files` internal rewrites of deep links by itself; verify a deep-link request (`/donations`) also carries the header, and if it does not, put the `add_header` on `location /` instead.
+
+**Watch out**: nginx `add_header` does not merge across levels. Any new block that declares its own `add_header` **discards every inherited security header** (CSP, X-Frame-Options, nosniff, Referrer-Policy). The existing asset regex block already has this bug — assets ship with no security headers today. Fixing that is out of scope for this plan, but do not _widen_ it: whichever block gets the new `Cache-Control` must repeat the five security headers, or use `include` for a shared snippet.
+
+### 1b. Compression
+
+```nginx
+gzip_comp_level 6;
+gzip_static on;
+gzip_types
+    text/plain text/css text/javascript
+    application/javascript application/json application/xml
+    image/svg+xml font/woff2;
+```
+
+Three separate gaps:
+
+- **Level**: default 1 → 6. This alone is the 15.1% win.
+- **Types**: current list misses `text/javascript` (what Vite-built `.js` is served as by nginx's default mime map — verify with `curl -I`), `font/woff2`, `application/wasm`.
+- **`gzip_static on`**: serves a precompressed `.js.gz` if one sits next to the file, at zero per-request CPU. Matters on the free Render plan.
+
+Precompress at build time with a small inline Vite plugin in `vite.config.ts` using `node:zlib` at level 9 — no new dependency, matching the repo's existing habit of inline config (`apiProxy`) over packages:
+
+```ts
+{
+  name: 'gzip-assets',
+  apply: 'build',
+  writeBundle(options, bundle) { /* gzipSync(level: 9) each .js/.css/.svg > 1024 B */ }
+}
+```
+
+`dist/` is gitignored, so the `.gz` files ride along in the Docker `COPY dist` with no repo noise.
+
+**Brotli is deliberately not done at origin**: `nginx:1.27-alpine` has no `ngx_brotli` module, so `brotli_static` would need a custom nginx build. Brotli belongs at the Cloudflare edge (a dashboard toggle, ~57 KB, zero code) — flag it to Jorge as a separate manual action, and re-check afterward whether Cloudflare passes origin gzip through or re-compresses.
+
+**Checkpoint 1 — measure before continuing.**
+
+```bash
+pnpm run build && docker build -t df-perf . && docker run --rm -p 8081:80 -e PORT=80 df-perf
+```
+
+- `curl -sI http://localhost:8081/ | grep -i cache-control` → `no-cache`
+- `curl -sI http://localhost:8081/donations` → same (deep-link check)
+- `curl -sI -H 'Accept-Encoding: gzip' http://localhost:8081/assets/index-*.js` → `content-encoding: gzip`, security headers still present
+- Byte comparison: served size vs `gzip -1` vs `gzip -9` on the same file. Expect the served size to match `gzip -9`, not `gzip -1`.
+- After deploy, repeat all of the above against the production URL — the audit's measured `gzip -1` figure is the baseline to beat.
+
+---
+
+## Phase 2 — lazy-load the date-range picker calendar
+
+`src/components/date-range-picker.tsx` statically imports `Calendar`, pulling react-day-picker into the entry path of `/`, `/donations`, `/expenses`, and `/reports` (six consumer sites; `donors` does not use it). The calendar only ever renders inside an open popover.
+
+Follow the established pattern in `src/features/dashboard/comparison-bar-chart.lazy.tsx` exactly: a `<name>.lazy.tsx` wrapper re-exporting the **same component name**, a `type`-only import of props, and a local `Suspense` whose fallback matches the real component's box so nothing shifts.
+
+- New `src/components/ui/calendar.lazy.tsx`: `lazy(() => import('./calendar').then((m) => ({ default: m.Calendar })))`.
+- `date-range-picker.tsx` imports from `./ui/calendar.lazy`; the trigger button stays eager so it cannot shift.
+- Fallback must be sized to the real two-month calendar (`numberOfMonths={2}`), measured from the rendered DOM, not guessed — a popover that resizes on chunk arrival is a worse experience than the current one.
+- Prefetch the chunk on the trigger's `onMouseEnter`/`onFocus` so the calendar is usually already resident by the time the popover opens.
+
+Keep `dayjs` eager — the trigger label formats with it and it is used app-wide.
+
+`Calendar` is also imported directly elsewhere; leave those call sites alone (surgical-change rule). Grep before editing to confirm which they are.
+
+**Checkpoint 2:**
+
+- `pnpm run test` — 397+ tests green; `src/components/ui/calendar.test.tsx` (10 keyboard-nav tests) must still pass. If the lazy boundary breaks them, the wrapper is wrong — do not weaken the tests.
+- `pnpm run typecheck`, `pnpm run check:ci`.
+- `pnpm run analyze` → confirm `date-range-picker-*.js` no longer appears in the dashboard's eager graph.
+- Browser: open the picker on `/` and on `/donations`, pick a range, confirm the query refires and the popover does not resize on chunk arrival.
+
+---
+
+## Phase 3 — font preload
+
+`/login` → `index-*.css` → `geist-latin-wght-normal.woff2` is a 390 ms three-hop chain; the font is not discoverable until the CSS parses. **This is not a CLS source** — that finding stays refuted (0.0000 attributed shift). The only cost is a late swap-in, and LCP is already 418 ms.
+
+The filename is content-hashed, so do **not** hardcode it in `index.html`. Emit the tag from a Vite `transformIndexHtml` hook that reads the woff2 filename out of the bundle:
+
+```html
+<link
+  rel="preload"
+  as="font"
+  type="font/woff2"
+  href="/assets/geist-...woff2"
+  crossorigin
+/>
+```
+
+`crossorigin` is required even same-origin — font fetches are CORS-mode, and omitting it double-fetches.
+
+**Checkpoint 3**: production trace showing the font request starting alongside the CSS rather than after it. **If the measured improvement is under ~100 ms, revert this phase** — it adds build machinery for a hashed filename and the audit already rated it "lower priority than it looks."
+
+---
+
+## Phase 4 — measure, then decide the deferred items
+
+These are _decisions_, not implementations. Each is currently gated on a number nobody has.
+
+**4a. Calendar forced reflow** (`src/components/ui/calendar.tsx:198-201`). ~70 day buttons each run a `useEffect` calling `ref.current?.focus()`. 47 ms attributed reflow, 280 ms INP — but that is a **dev-server figure at 4× throttle**, the least trustworthy number in the audit. Get production INP on the picker (Phase 2 changes the load path, so measure after it lands). **If it lands under 200 ms, close this and change nothing** — the focus behaviour is an accessibility requirement (`cde0184`), and 9 of 10 calendar tests fail without it. Only if it is genuinely slow, hoist one effect to the calendar root targeting the currently-focused day.
+
+**4b. Sidebar route prefetch** (`src/layouts/sidebar.tsx:114`). Plain `NavLink`: click → download chunk → mount → _then_ query. Warming the route module on `onMouseEnter` captures most of it; the cost is coupling the sidebar to route module paths. Unquantified in production — measure a cold sidebar navigation, and only act if the chunk hop is a material share of the total.
+
+**4c. Lazy `AppLayout`** (`src/app-routes.tsx`). The audit's own analysis argues against it: base-ui is pinned to `/login` independently by `TooltipProvider`/`ToastProvider`/`Input`, so the recovery is well under the ~35 KB first estimated, and it _introduces_ a waterfall for already-authenticated arrivals. **Recommend closing as won't-do** unless the auth-state distribution of real traffic says otherwise.
+
+**4d. Field data.** There is no CrUX data for this origin — it is below the reporting threshold, and every number in #172 is lab data. A `web-vitals` beacon would give real INP attribution no lab run can. Worth a separate issue, not this plan.
+
+---
+
+## Deliverables
+
+- `docs/plans/web-perf-followup.md` — this plan (repo convention: `docs/plans/`, alongside the 40+ existing plans).
+- `docs/plans/web-perf-followup-todo.md` — the task checklist.
+- One PR per phase, conventional-commit titled (CI enforces it): `perf(nginx):`, `perf(calendar):`, `perf(fonts):`.
+- Close #172 with the measured results, including the items decided as won't-do — the issue's own framing is that refuted findings must be documented so they are not re-raised.
+- Delete the now-redundant local `feat-exp-web-perf` branch.
+
+## Verification
+
+Full gate before each PR: `pnpm run typecheck && pnpm run check:ci && pnpm run test && pnpm run build`.
+
+Performance verification is measurement, not inspection — every phase ships with a before/after number:
+
+```bash
+pnpm run build && pnpm run preview   # :4173, proxies /api
+pnpm run lighthouse                  # writes to gitignored .lighthouse/
+```
+
+Deeper traces use the `chrome-devtools` MCP server (already in `.mcp.json`).
+
+**Two caveats carried over from the audit, both of which make preview numbers untrustworthy:**
+
+- The session token is origin-scoped to `:3000`, so `:4173` needs a manual login before authenticated routes can be traced.
+- Do not measure against real production donation records. The last audit hit the authenticated dashboard **incidentally** — the browser profile held a live production session that the SPA restored mid-run. Seed a staging instance with fake data instead, and measure a **populated** date range: the last dashboard numbers came from an empty August 2026 range.

--- a/security-headers.conf
+++ b/security-headers.conf
@@ -1,0 +1,8 @@
+# Included from every location that declares its own add_header, because nginx
+# add_header does not merge across levels: one declaration in a nested block
+# drops every header inherited from the server block.
+add_header X-Frame-Options "SAMEORIGIN" always;
+add_header X-Content-Type-Options "nosniff" always;
+add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+add_header X-XSS-Protection "1; mode=block" always;
+add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'" always;

--- a/security-headers.conf
+++ b/security-headers.conf
@@ -5,4 +5,9 @@ add_header X-Frame-Options "SAMEORIGIN" always;
 add_header X-Content-Type-Options "nosniff" always;
 add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 add_header X-XSS-Protection "1; mode=block" always;
-add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'" always;
+# The sha256 covers the inline theme script in index.html, which sets the dark
+# class before first paint. Without it script-src 'self' blocks the script in
+# production - it runs in dev only because vite serves no CSP - and every load
+# flashes light before React hydrates. Editing that script changes the hash;
+# tests/csp-inline-script.test.ts fails when the two drift apart.
+add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'sha256-cSY16av0cTk9ahaQUy4qAVCqOvIAv9Ybu9NW2y9FeZs='; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'" always;

--- a/src/components/date-range-picker.tsx
+++ b/src/components/date-range-picker.tsx
@@ -3,7 +3,7 @@ import { CalendarIcon } from 'lucide-react'
 import { useState } from 'react'
 import { type DateRange } from 'react-day-picker'
 import { useTranslation } from 'react-i18next'
-import { Calendar } from '@/components/ui/calendar'
+import { Calendar, prefetchCalendar } from '@/components/ui/calendar.lazy'
 import {
   Popover,
   PopoverContent,
@@ -37,6 +37,10 @@ export function DateRangePicker({ from, to, onChange }: DateRangePickerProps) {
             type="button"
             aria-expanded={open}
             aria-haspopup="dialog"
+            // The calendar is code split. Warming it on intent means the
+            // chunk is usually resident by the time the popover opens.
+            onMouseEnter={() => void prefetchCalendar()}
+            onFocus={() => void prefetchCalendar()}
             className={cn(
               'bg-background inline-flex shrink-0 items-center justify-start gap-2 rounded-lg border px-3 py-1.5 text-left text-sm font-normal',
               'hover:bg-accent hover:text-accent-foreground',

--- a/src/components/ui/calendar.lazy.test.tsx
+++ b/src/components/ui/calendar.lazy.test.tsx
@@ -1,0 +1,50 @@
+import { render, waitFor } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { Calendar, prefetchCalendar } from './calendar.lazy'
+
+const JANUARY_2026 = new Date(2026, 0, 1)
+
+describe('Calendar (lazy)', () => {
+  // react-day-picker is ~29 KB gzip and only ever renders inside an open
+  // popover, so the first paint is the fallback. It must hold the same box the
+  // calendar will, or the popover resizes when the chunk lands.
+  it('renders a placeholder sized to the month grid before the chunk loads', () => {
+    const { container } = render(
+      <Calendar mode="range" defaultMonth={JANUARY_2026} numberOfMonths={2} />
+    )
+
+    const placeholders = container.querySelectorAll('.animate-pulse')
+    expect(placeholders).toHaveLength(2)
+    expect(
+      container.querySelector('[data-slot="calendar-fallback"]')
+    ).toHaveClass('p-2')
+  })
+
+  it('renders one placeholder month by default', () => {
+    const { container } = render(<Calendar mode="single" />)
+
+    expect(container.querySelectorAll('.animate-pulse')).toHaveLength(1)
+  })
+
+  it('renders the calendar once the chunk resolves', async () => {
+    const { container } = render(
+      <Calendar mode="range" defaultMonth={JANUARY_2026} numberOfMonths={2} />
+    )
+
+    // Generous timeout: the first transform of react-day-picker in this
+    // environment takes about a second, well past waitFor's 1s default.
+    await waitFor(
+      () => {
+        expect(container.querySelectorAll('[data-day]').length).toBeGreaterThan(
+          0
+        )
+      },
+      { timeout: 5000 }
+    )
+    expect(container.querySelector('.animate-pulse')).not.toBeInTheDocument()
+  })
+
+  it('prefetches the chunk without rendering anything', async () => {
+    await expect(prefetchCalendar()).resolves.toHaveProperty('Calendar')
+  })
+})

--- a/src/components/ui/calendar.lazy.test.tsx
+++ b/src/components/ui/calendar.lazy.test.tsx
@@ -18,6 +18,16 @@ describe('Calendar (lazy)', () => {
     expect(
       container.querySelector('[data-slot="calendar-fallback"]')
     ).toHaveClass('p-2')
+
+    // Measured against the rendered calendar: 196px wide (7 cells) by 278px
+    // tall at six week rows. These are the whole point of the fallback - if
+    // they drift the popover resizes when the chunk lands.
+    for (const placeholder of placeholders) {
+      expect(placeholder).toHaveClass(
+        'h-[278px]',
+        'w-[calc(var(--cell-size)*7)]'
+      )
+    }
   })
 
   it('renders one placeholder month by default', () => {

--- a/src/components/ui/calendar.lazy.tsx
+++ b/src/components/ui/calendar.lazy.tsx
@@ -1,0 +1,58 @@
+import { type ComponentProps, lazy, Suspense } from 'react'
+import { cn } from '@/lib/utils'
+import type { Calendar as CalendarComponent } from './calendar'
+
+type CalendarProps = ComponentProps<typeof CalendarComponent>
+
+// react-day-picker is 29 KB gzip and the calendar only ever renders inside an
+// open popover, so it loads on demand rather than on every route that carries a
+// date range picker.
+const LazyCalendar = lazy(() =>
+  import('./calendar').then((m) => ({ default: m.Calendar }))
+)
+
+// Warm the chunk from a trigger's hover/focus so the popover usually opens with
+// the calendar already resident.
+export function prefetchCalendar() {
+  return import('./calendar')
+}
+
+export function Calendar({ className, ...props }: CalendarProps) {
+  const months = props.numberOfMonths ?? 1
+
+  return (
+    <Suspense
+      fallback={<CalendarFallback months={months} className={className} />}
+    >
+      <LazyCalendar className={className} {...props} />
+    </Suspense>
+  )
+}
+
+// Mirrors the real calendar's box: same padding, same --cell-size, and a block
+// per month sized to the grid it will hold — a caption row, a weekday row and
+// six week rows, with the gap-4 between caption and grid.
+function CalendarFallback({
+  months,
+  className,
+}: {
+  months: number
+  className?: string
+}) {
+  return (
+    <div
+      data-slot="calendar-fallback"
+      aria-hidden="true"
+      className={cn('bg-background p-2 [--cell-size:--spacing(7)]', className)}
+    >
+      <div className="flex flex-col gap-4 md:flex-row">
+        {Array.from({ length: months }, (_, i) => (
+          <div
+            key={i}
+            className="h-[calc(var(--cell-size)*8+1rem)] w-[calc(var(--cell-size)*7)] animate-pulse rounded-md bg-muted"
+          />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/ui/calendar.lazy.tsx
+++ b/src/components/ui/calendar.lazy.tsx
@@ -29,9 +29,15 @@ export function Calendar({ className, ...props }: CalendarProps) {
   )
 }
 
-// Mirrors the real calendar's box: same padding, same --cell-size, and a block
-// per month sized to the grid it will hold — a caption row, a weekday row and
-// six week rows, with the gap-4 between caption and grid.
+// Mirrors the real calendar's box, measured from the rendered DOM rather than
+// derived: a month is 196px wide (7 cells at --cell-size 28) and 278px tall at
+// six week rows — caption 28, gap 16, weekday row 18, six rows of 36 — over the
+// footer line and the root's p-2.
+//
+// A month with five week rows is 242px, and the row count isn't knowable until
+// the chunk lands, so this sizes for six. The popover can therefore shrink by a
+// row on arrival but never grow, which is the direction that doesn't cover what
+// the user is looking at.
 function CalendarFallback({
   months,
   className,
@@ -49,10 +55,11 @@ function CalendarFallback({
         {Array.from({ length: months }, (_, i) => (
           <div
             key={i}
-            className="h-[calc(var(--cell-size)*8+1rem)] w-[calc(var(--cell-size)*7)] animate-pulse rounded-md bg-muted"
+            className="h-[278px] w-[calc(var(--cell-size)*7)] animate-pulse rounded-md bg-muted"
           />
         ))}
       </div>
+      <div className="h-4" />
     </div>
   )
 }

--- a/tests/csp-inline-script.test.ts
+++ b/tests/csp-inline-script.test.ts
@@ -1,0 +1,28 @@
+import { createHash } from 'node:crypto'
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+// The theme script in index.html has to run before first paint, so it is
+// inline, and script-src 'self' blocks inline scripts. nginx allows this one by
+// its sha256. Nothing at runtime notices when they drift: dev serves no CSP, so
+// the breakage only shows in production, as a light flash on every load for
+// dark mode users.
+describe('CSP hash for the inline theme script', () => {
+  it('matches the script in index.html', () => {
+    const html = readFileSync('index.html', 'utf8')
+    const script = html.match(
+      /<script(?![^>]*\ssrc)[^>]*>([\s\S]*?)<\/script>/
+    )?.[1]
+    expect(script, 'no inline script found in index.html').toBeDefined()
+
+    const hash = `sha256-${createHash('sha256')
+      .update(script as string, 'utf8')
+      .digest('base64')}`
+    const nginx = readFileSync('security-headers.conf', 'utf8')
+
+    expect(
+      nginx,
+      `index.html's inline script hashes to '${hash}'. Update script-src in security-headers.conf.`
+    ).toContain(`'${hash}'`)
+  })
+})

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -21,5 +21,5 @@
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["vite.config.ts", "vitest.config.ts"]
+  "include": ["vite.config.ts", "vitest.config.ts", "tests"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,11 @@
+import { writeFileSync } from 'node:fs'
 import path from 'node:path'
+import { gzipSync } from 'node:zlib'
 import babel from '@rolldown/plugin-babel'
 import tailwindcss from '@tailwindcss/vite'
 import react, { reactCompilerPreset } from '@vitejs/plugin-react'
 import { visualizer } from 'rollup-plugin-visualizer'
-import { defineConfig, type ProxyOptions } from 'vite'
+import { defineConfig, type Plugin, type ProxyOptions } from 'vite'
 
 const PORT = 3000
 // Shared by dev and preview so a production build can be measured against the
@@ -24,12 +26,40 @@ const apiProxy: Record<string, ProxyOptions> = {
 // reachable enough that a green build still means something.
 const CHUNK_SIZE_WARNING_KB = 360
 
+// Matches gzip_min_length in default.conf.template.
+const GZIP_MIN_BYTES = 1024
+const COMPRESSIBLE = /\.(?:js|css|svg)$/
+
+// Writes a level-9 .gz next to each compressible asset. nginx has gzip_static
+// on, so it serves these instead of recompressing immutable bytes per request
+// — and at a level the per-request path can't afford. Assets are content
+// hashed, so the .gz never goes stale.
+function gzipAssets() {
+  return {
+    name: 'gzip-assets',
+    apply: 'build',
+    writeBundle(options, bundle) {
+      for (const [fileName, chunk] of Object.entries(bundle)) {
+        if (!COMPRESSIBLE.test(fileName)) continue
+
+        const source = chunk.type === 'chunk' ? chunk.code : chunk.source
+        const raw = Buffer.from(source)
+        if (raw.byteLength < GZIP_MIN_BYTES) continue
+
+        const target = path.join(options.dir ?? 'dist', fileName)
+        writeFileSync(`${target}.gz`, gzipSync(raw, { level: 9 }))
+      }
+    },
+  } satisfies Plugin
+}
+
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [
     react({}),
     babel({ presets: [reactCompilerPreset()] }),
     tailwindcss(),
+    gzipAssets(),
     // pnpm run analyze
     process.env.ANALYZE &&
       visualizer({ filename: 'dist/stats.html', gzipSize: true }),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -53,12 +53,56 @@ function gzipAssets() {
   } satisfies Plugin
 }
 
+// The only subset this Spanish-only app ever fetches; cyrillic and latin-ext
+// stay behind their unicode-range and must not be preloaded.
+const LATIN_FONT = /geist-latin-wght-normal-[^/]*\.woff2$/
+
+// The font sits at the end of a three-hop chain - html, css, then woff2 - so it
+// is not discoverable until the CSS parses. A preload flattens that. The
+// filename is content hashed, so it is read from the bundle rather than
+// hardcoded.
+function preloadLatinFont(): Plugin {
+  return {
+    name: 'preload-latin-font',
+    apply: 'build',
+    transformIndexHtml: {
+      order: 'post',
+      handler(_html, ctx) {
+        const font = Object.keys(ctx.bundle ?? {}).find((name) =>
+          LATIN_FONT.test(name)
+        )
+        if (!font) {
+          this.warn('No latin geist woff2 in the bundle; skipping preload.')
+          return
+        }
+
+        return [
+          {
+            tag: 'link',
+            // crossorigin is required even same-origin: font requests are
+            // CORS mode, and without it the browser fetches the file twice.
+            attrs: {
+              rel: 'preload',
+              as: 'font',
+              type: 'font/woff2',
+              href: `/${font}`,
+              crossorigin: '',
+            },
+            injectTo: 'head-prepend',
+          },
+        ]
+      },
+    },
+  }
+}
+
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [
     react({}),
     babel({ presets: [reactCompilerPreset()] }),
     tailwindcss(),
+    preloadLatinFont(),
     gzipAssets(),
     // pnpm run analyze
     process.env.ANALYZE &&

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { writeFileSync } from 'node:fs'
+import { readFileSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
 import { gzipSync } from 'node:zlib'
 import babel from '@rolldown/plugin-babel'
@@ -34,19 +34,23 @@ const COMPRESSIBLE = /\.(?:js|css|svg)$/
 // on, so it serves these instead of recompressing immutable bytes per request
 // — and at a level the per-request path can't afford. Assets are content
 // hashed, so the .gz never goes stale.
+//
+// Each .gz is compressed from the file on disk, not from the in-memory chunk:
+// gzip_static serves the .gz whenever it exists, without ever comparing it to
+// the plain file, so anything that rewrites a file after this hook would
+// otherwise ship silently stale bytes.
 function gzipAssets() {
   return {
     name: 'gzip-assets',
     apply: 'build',
     writeBundle(options, bundle) {
-      for (const [fileName, chunk] of Object.entries(bundle)) {
+      for (const fileName of Object.keys(bundle)) {
         if (!COMPRESSIBLE.test(fileName)) continue
 
-        const source = chunk.type === 'chunk' ? chunk.code : chunk.source
-        const raw = Buffer.from(source)
+        const target = path.join(options.dir ?? 'dist', fileName)
+        const raw = readFileSync(target)
         if (raw.byteLength < GZIP_MIN_BYTES) continue
 
-        const target = path.join(options.dir ?? 'dist', fileName)
         writeFileSync(`${target}.gz`, gzipSync(raw, { level: 9 }))
       }
     },


### PR DESCRIPTION
## What

Closes the remaining open items from the audit in #172, plus one production bug found while verifying them.

Note the issue's priority 3 ("deploy the branch") was already done: #173 landed every dashboard fix and shipped in 0.3.8. The local `feat-exp-web-perf` branch is redundant and can be deleted.

The audit called its top two findings "infrastructure, not code — neither lives in this repo." That was wrong. `default.conf.template` is in this repo and had `gzip on` with no `gzip_comp_level`, which is exactly why production served `gzip -1` bytes.

## Results

| What | Before | After |
|---|---:|---:|
| Entry chunk over the wire | 98,926 B (`gzip -1`) | 84,607 B (build-time `gzip -9` via `gzip_static`) |
| `date-range-picker` chunk, eager | 93.19 kB / 29.06 kB gzip | 22.53 kB / 9.04 kB gzip |
| Calendar (`react-day-picker`) | eager on 4 routes | 21.40 kB gzip, on demand |
| Font request start | after CSS parse (387 ms in prod) | 12 ms, same burst as CSS and entry JS |
| `index.html` caching | no `Cache-Control` at all | `no-cache` (revalidate) |
| Inline theme script in prod | blocked by CSP | runs; dark class set before first paint |

## Changes

**nginx** — `index.html` shipped with no `Cache-Control`, so browsers applied heuristic freshness (~10% of document age; production's `Last-Modified` was 13 days old). That HTML references content-hashed assets which stop existing after a deploy — a blank page, not a slow one. `no-cache` means revalidate, not don't-store: bfcache stays intact.

Compression was effectively off. Level 6 for per-request work, `gzip_static` for the level-9 files the build now emits, and the type list gains `text/javascript`, `font/woff2`, `application/wasm`, `application/xml`.

The five security headers moved to `security-headers.conf`, `include`d from both blocks — nginx `add_header` does not merge across levels, so adding `Cache-Control` to `location /` would otherwise have dropped CSP from every HTML response.

**Calendar** — `react-day-picker` sat in the eager graph of `/`, `/donations`, `/expenses` and `/reports` for a calendar that only renders inside an open popover. Follows the existing `comparison-bar-chart.lazy.tsx` pattern; the trigger stays eager and warms the chunk on hover/focus. The fallback box is measured from the rendered DOM (196×278 px at six week rows), sized so the popover can shrink on arrival but never grow.

**CSP** — found while verifying the headers in a real container: `script-src 'self'` blocked the anti-FOUC theme script, so dark mode flashed light on every production load. Dev never showed it because vite serves no CSP. Fixed by hash, not by `'unsafe-inline'`. `tests/csp-inline-script.test.ts` recomputes the hash from `index.html` so the two can't drift silently.

## Verification

Every number above is measured, not inferred.

- nginx headers and byte sizes: `nginx:1.27-alpine` serving the real `dist`. `/` and `/donations` both return `no-cache` plus all five security headers; assets keep `public, immutable` and are served as the build `.gz`.
- Authenticated production build on `vite preview` against the local API: range change refires the six-query fan-out with **CLS 0**; dashboard load CLS 0.
- **INP: 40 ms opening the picker, 48 ms clicking a day, zero long tasks.**
- `/login` Lighthouse: 100, LCP 0.6 s, CLS 0 — unchanged.
- 402 tests pass (5 added), typecheck and Biome clean.

## Decisions taken, so they aren't re-raised

- **Calendar forced reflow — won't fix.** The audit's 280 ms was the dev server at 4× CPU throttle. A production build measures 40–48 ms with no long task. The focus behaviour is an accessibility requirement and 9 of 10 keyboard tests depend on it.
- **Lazy `AppLayout` — won't do**, on the audit's own reasoning: it introduces a waterfall for already-authenticated arrivals and recovers well under the 35 KB first estimated.
- **Sidebar prefetch — deferred.** Ordering confirmed (chunk, then mount, then query) but it costs 7 ms locally. Needs a production number before coupling the sidebar to route module paths.
- The recharts namespace import and the font-CLS finding **stay refuted**.

## Not in this PR

- **Brotli at the Cloudflare edge** (~57 KB, 25% of the critical path) — a dashboard toggle. `nginx:1.27-alpine` has no `ngx_brotli`, so origin Brotli would need a custom build.
- Production verification of the cache and compression headers, after this deploys.
- A `web-vitals` field beacon. CrUX has nothing for this origin; every number in #172 is lab data.
- Pre-existing and untouched: the asset regex block ships no security headers (same `add_header` non-merge cause), and assets return two `Cache-Control` headers that concatenate harmlessly.
