### PR TITLE
fix(a11y): wire login errors to the fields they describe

### DIFF
--- a/src/features/auth/login-page.test.tsx
+++ b/src/features/auth/login-page.test.tsx
@@ -1,6 +1,6 @@
 import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { http } from 'msw'
+import { delay, HttpResponse, http } from 'msw'
 import { Route, Routes } from 'react-router'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { server } from '@/test/msw-server'
@@ -31,6 +31,62 @@ describe('LoginPage', () => {
     expect(screen.getByLabelText('Usuario')).toBeInTheDocument()
     expect(screen.getByLabelText('Contraseña')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Ingresar' })).toBeInTheDocument()
+  })
+
+  it('renders the title as the page heading', () => {
+    renderWithProviders(<TestApp />, { route: '/login' })
+    expect(
+      screen.getByRole('heading', { level: 1, name: 'Iniciar sesión' })
+    ).toBeInTheDocument()
+  })
+
+  it('leaves the fields unassociated while there is no error', () => {
+    renderWithProviders(<TestApp />, { route: '/login' })
+
+    for (const label of ['Usuario', 'Contraseña']) {
+      const field = screen.getByLabelText(label)
+      expect(field).toHaveAttribute('aria-invalid', 'false')
+      expect(field).not.toHaveAttribute('aria-describedby')
+    }
+  })
+
+  it('points both fields at the error once login fails', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<TestApp />, { route: '/login' })
+
+    await user.type(screen.getByLabelText('Usuario'), 'wrong')
+    await user.type(screen.getByLabelText('Contraseña'), 'wrong')
+    await user.click(screen.getByRole('button', { name: 'Ingresar' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveAttribute('id', 'login-error')
+    })
+    for (const label of ['Usuario', 'Contraseña']) {
+      const field = screen.getByLabelText(label)
+      expect(field).toHaveAttribute('aria-invalid', 'true')
+      expect(field).toHaveAttribute('aria-describedby', 'login-error')
+    }
+  })
+
+  it('marks the submit button busy while it waits on the API', async () => {
+    const user = userEvent.setup()
+    server.use(
+      http.post('*/api/v1/login', async () => {
+        await delay('infinite')
+        return HttpResponse.json({})
+      })
+    )
+    renderWithProviders(<TestApp />, { route: '/login' })
+
+    await user.type(screen.getByLabelText('Usuario'), 'admin')
+    await user.type(screen.getByLabelText('Contraseña'), 'random')
+    await user.click(screen.getByRole('button', { name: 'Ingresar' }))
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'Ingresando...' })
+      ).toHaveAttribute('aria-busy', 'true')
+    })
   })
 
   it('redirects to dashboard on successful login', async () => {

--- a/src/features/auth/login-page.tsx
+++ b/src/features/auth/login-page.tsx
@@ -1,10 +1,11 @@
 import { login as sdkLogin } from '@jorgetroya80/donations-api-client'
+import { CircleAlert } from 'lucide-react'
 import { type SyntheticEvent, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Card, CardContent, CardHeader } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { client } from '@/lib/api'
@@ -74,18 +75,24 @@ export function LoginPage() {
     }
   }
 
+  const errorId = error ? 'login-error' : undefined
+
   return (
-    <div className="flex min-h-screen items-center justify-center bg-muted">
+    <main className="flex min-h-screen items-center justify-center bg-muted">
       <Card className="w-full max-w-sm">
         <CardHeader>
-          <CardTitle className="text-center text-2xl">
+          {/* CardTitle renders a div; the page needs a real h1 (1.3.1).
+              Same classes, minus text-balance — the base layer already
+              applies it to every h1. */}
+          <h1 className="font-heading text-center text-2xl leading-snug font-medium">
             {t('auth.login')}
-          </CardTitle>
+          </h1>
         </CardHeader>
         <CardContent>
           <form onSubmit={handleSubmit} className="space-y-4">
             {error && (
-              <Alert variant="destructive">
+              <Alert variant="destructive" id="login-error">
+                <CircleAlert aria-hidden="true" />
                 <AlertDescription>{error}</AlertDescription>
               </Alert>
             )}
@@ -96,6 +103,8 @@ export function LoginPage() {
                 name="username"
                 required
                 autoComplete="username"
+                aria-invalid={!!error}
+                aria-describedby={errorId}
               />
             </div>
             <div className="space-y-2">
@@ -106,14 +115,21 @@ export function LoginPage() {
                 type="password"
                 required
                 autoComplete="current-password"
+                aria-invalid={!!error}
+                aria-describedby={errorId}
               />
             </div>
-            <Button type="submit" className="w-full" disabled={loading}>
+            <Button
+              type="submit"
+              className="w-full"
+              disabled={loading}
+              aria-busy={loading}
+            >
               {loading ? t('auth.submitting') : t('auth.submit')}
             </Button>
           </form>
         </CardContent>
       </Card>
-    </div>
+    </main>
   )
 }


### PR DESCRIPTION
Login error sat in an `Alert` with no link to the inputs. A screen reader user who tabbed back to a field heard nothing about why it was rejected.

Independent of #180 — zero file overlap, merges in either order.

## Changes

All in `src/features/auth/login-page.tsx`:

- Both fields get `aria-invalid` and `aria-describedby` pointing at the alert (SC 3.3.1)
- Real `<h1>`. `CardTitle` renders a div, so the page had no heading at all (SC 1.3.1)
- `<main>` landmark
- Icon in the alert, so the error is not signalled by colour alone (SC 1.4.1)
- `aria-busy` on the submit button

With no error the fields read `aria-invalid="false"` and carry no `aria-describedby` at all — the attribute is omitted, not emptied.

## Two calls worth flagging

**Focus is not moved to the alert**, which the design proposed. `Alert` already carries `role="alert"` with `aria-live="assertive"`; doing both makes several screen readers announce it twice. Association is the standard pattern here.

**The `<h1>` replaces `CardTitle` rather than wrapping it.** `CardTitle` is a plain div in this repo, not base-ui, so it takes no `render` prop. A bare `<h1>` with its classes at this one call site beats changing a shared component. `text-balance` dropped — the base layer already applies it to every `h1`.

The wiring follows `donor-form.tsx`, which already does this; no new pattern invented.

## Verified

Four new tests, nine existing ones untouched. 406 tests, typecheck, biome, build. Attributes read off the running app in both the error and the clean state.

Lighthouse on `/login`: `landmark-one-main` now passes.

Score reads 96 here against 98 on #180, which is branch composition and not a regression. What fails is `target-size` — the password toggle at 16px, whose fix lives in #180. With both merged, neither fails.
