### PR TITLE
feat(dashboard): rank categories instead of charts

### DIFF
--- a/docs/PRD-dashboard-category-ranking.md
+++ b/docs/PRD-dashboard-category-ranking.md
@@ -1,0 +1,239 @@
+# Spec: Replace dashboard comparison bar charts with a category ranking
+
+## Objective
+
+Replace the two `ComparisonBarChart` cards in
+[financial-overview.tsx](../src/features/dashboard/financial-overview.tsx) — "Donaciones por tipo"
+and "Gastos por categoría" — with a ranked list: one row per category, sorted descending, showing a
+proportional bar, the exact amount, and the variation against the previous period.
+
+**Target users:** treasurers (`canViewReports`) landing on the dashboard.
+
+**Problem:** the current charts render two horizontal bar series (current + previous) with no axis
+and no value labels, so no figure is readable without hovering. A shared linear scale flattens
+everything below the largest category — with IRPF at 21.450 € and Mantenimiento at 310 €, the small
+bar is a 2 px sliver. The comparison the charts perform (current vs previous) is already answered by
+the three `StatCard`s directly above them.
+
+**Outcome:** every category shows its exact amount and its variation without interaction; the
+biggest cost sits at the top; the card stops competing with the stat cards above it.
+
+**Not in scope:** the monthly trend chart. That needs time-series endpoints, tracked in
+[donations-api#51](https://github.com/jorgetroya80/donations-api/issues/51), and lands as a separate
+spec once the API ships.
+
+## Assumptions
+
+1. Zero new API calls. The six queries in `FinancialOverview` (`balance`, `donations`, `expenses` ×
+   current/previous) stay exactly as they are — this design consumes data already in memory.
+2. The date range picker, the `StatCard` row, and `QuickActions` are untouched.
+3. Spanish stays the only locale; new strings go in `src/locales/es.json`.
+4. The design is the "Opción A" artboard reviewed on 2026-08-25.
+
+## Tech stack
+
+React 19 · TypeScript · Vite 8 · Tailwind v4 · react-i18next · TanStack Query 5 ·
+Vitest + Testing Library + MSW. No new dependencies.
+
+## Commands
+
+- `pnpm run check` — Biome lint + format + import organizing
+- `pnpm run typecheck` — `tsc --build --force`
+- `pnpm run test` — unit tests
+- `pnpm run build` — production build
+- `pnpm run dev` — dev server (port 3000)
+
+## Project structure (files touched)
+
+```
+src/features/dashboard/
+  category-ranking.tsx        NEW — presentational ranked list
+  category-ranking.test.tsx   NEW — colocated tests
+  pct-change.tsx              NEW — PctChange extracted from stat-card.tsx
+  stat-card.tsx               EDIT — import PctChange instead of defining it
+  financial-overview.tsx      EDIT — build ranking rows, render CategoryRanking
+  financial-overview.test.tsx EDIT — assert on rows instead of chart mocks
+src/locales/es.json           EDIT — new keys
+```
+
+## Component contract
+
+```tsx
+export interface RankingItem {
+  key: string          // API enum value: 'TITHE' | 'IRPF' | …
+  label: string        // already translated
+  current: number
+  previous: number | null | undefined
+}
+
+export interface CategoryRankingProps {
+  items: RankingItem[]
+  inverted?: boolean   // true for expenses: an increase is bad
+}
+
+export function CategoryRanking({ items, inverted }: CategoryRankingProps)
+```
+
+Presentational only: no hooks into React Query, no `t()` calls for category names (the caller
+translates), no sorting decisions left to the caller.
+
+### Rendering rules
+
+1. **Sort** descending by `current`. Ties break by `label` (`localeCompare`, stable across renders).
+2. **Bar width** is `current / max(...items.current) * 100`%, so the largest row is always full
+   width. A row with `current === 0` renders a zero-width bar. Every bar has `min-w-[3px]` so a
+   present-but-tiny category stays visible.
+3. **Track**: `bg-muted` behind the bar, marking the 100 % reference. `aria-hidden` — it is
+   decoration, the number next to it is the content.
+4. **Amount** via `formatCurrency` from [formatters.ts](../src/lib/formatters.ts).
+5. **Variation** via the extracted `PctChange`, with `inverted` passed through. Same visual language
+   as the stat cards above (`↑`/`↓` + one decimal, `text-success` / `text-destructive`) — this
+   deliberately differs from the mockup's `+15,7 %` so the two blocks read as one system.
+6. **New category**: when `calcPctChange` returns `null` because `previous` is `0` or missing and
+   `current > 0`, render `t('dashboard.newCategory')` in `text-muted-foreground` — not an arrow.
+7. **Empty `items`** renders nothing; the caller keeps showing its existing `EmptyState`.
+
+### Markup
+
+A `<table>` — this is tabular data (category, amount, variation) and a table gives screen readers
+row/column context for free. The bar lives inside the category cell as an `aria-hidden` decoration.
+`<caption className="sr-only">` names the table, since the visible `CardTitle` sits outside it.
+
+## Caller changes in `financial-overview.tsx`
+
+1. **Union both periods** when building expense rows. Today expense rows map over
+   `expenses.data?.totalsByCategory` only ([financial-overview.tsx:73](../src/features/dashboard/financial-overview.tsx:73)),
+   so a category that existed last period and is `0` now silently disappears — a −100 % that never
+   shows. Donations already union both sets
+   ([financial-overview.tsx:60](../src/features/dashboard/financial-overview.tsx:60)); mirror that
+   for expenses.
+2. **Drop the Diezmo/otros split.** `titheData` / `otherDonationsData` exist only because the two
+   charts needed different `max-h` classes. One ranking replaces both.
+3. **Card header** shows the period total from `grandTotal` (`DonationSummaryResponse.grandTotal` /
+   `ExpenseSummaryResponse.grandTotal`) — an existing DTO field the dashboard does not use yet.
+4. `comparisonConfig` and the `ChartConfig` import become unused for the comparison charts;
+   `donationChartConfig` is still needed for the type labels.
+
+## New i18n keys (`src/locales/es.json`)
+
+```json
+"dashboard": {
+  "newCategory": "nuevo",
+  "periodTotal": "total {{amount}}",
+  "rankingCaption": "{{title}}, importe y variación frente al periodo anterior"
+}
+```
+
+## Code style
+
+Match the surrounding feature slice: kebab-case file names, plain HTML + Tailwind v4, no wrappers
+around base-ui, no manual `useMemo`/`useCallback` (React Compiler), Biome formatting.
+
+```tsx
+const rows = [...items].sort((a, b) => b.current - a.current || a.label.localeCompare(b.label))
+const max = rows[0]?.current ?? 0
+
+return (
+  <table className="w-full text-sm">
+    <caption className="sr-only">{caption}</caption>
+    <tbody>
+      {rows.map((item) => (
+        <tr key={item.key}>
+          <td className="py-1.5 pr-3 text-right align-middle whitespace-nowrap">{item.label}</td>
+          <td className="w-full py-1.5">
+            <div aria-hidden="true" className="bg-muted h-5 rounded">
+              <div
+                className="bg-chart-1 h-5 min-w-[3px] rounded"
+                style={{ width: `${max > 0 ? (item.current / max) * 100 : 0}%` }}
+              />
+            </div>
+          </td>
+          <td className="py-1.5 pl-3 text-right font-medium whitespace-nowrap">
+            {formatCurrency(item.current)}
+          </td>
+          <td className="py-1.5 pl-3 text-right whitespace-nowrap">
+            <PctChange current={item.current} previous={item.previous} inverted={inverted} />
+          </td>
+        </tr>
+      ))}
+    </tbody>
+  </table>
+)
+```
+
+## Testing strategy
+
+Vitest + Testing Library, colocated `*.test.tsx`, rendered through
+[test-utils.tsx](../src/test/test-utils.tsx), API mocked with
+[msw-handlers.ts](../src/test/msw-handlers.ts). Never assert against the real network.
+
+`category-ranking.test.tsx`:
+
+1. Rows come out sorted descending regardless of input order.
+2. The largest row's bar is `width: 100%`; a proportionally smaller row is not.
+3. `previous: 0` with `current > 0` renders "nuevo", not a percentage.
+4. `previous > 0` with `current: 0` renders a −100 % decrease.
+5. `inverted` flips the colour: an increase is `text-destructive` in expenses,
+   `text-success` in donations.
+6. Empty `items` renders nothing.
+
+`financial-overview.test.tsx`:
+
+7. A category present only in the previous period still renders a row (the union fix).
+8. Both card totals render from `grandTotal`.
+9. The existing loading / error / empty-state assertions still pass.
+
+`stat-card.test.tsx` must pass **unchanged** after `PctChange` is extracted — that is the proof the
+extraction was behaviour-preserving.
+
+Manual pass (`pnpm run dev`, treasurer account): change the date range and confirm rows re-sort and
+totals track; check dark mode; check a narrow viewport (the ranking must not overflow its card).
+
+## Boundaries
+
+**Always:**
+
+- Keep the six existing report queries as they are — no new requests, no new hooks.
+- Reuse `formatCurrency`, `calcPctChange`, `Card`, `EmptyState`.
+- Run `pnpm run check`, `pnpm run typecheck` and `pnpm run test` before committing.
+- Branch and PR; never commit to `main`.
+
+**Ask first:**
+
+- Any change to `StatCard`'s rendered output.
+- Adding a locale key outside the `dashboard` namespace.
+
+**Never:**
+
+- Fabricate or client-side-derive a monthly series to fake the trend chart before
+  [donations-api#51](https://github.com/jorgetroya80/donations-api/issues/51) ships.
+- Touch `QuickActions`, `UserStats`, or the date range picker.
+- Remove the `EmptyState` branches.
+- Delete `comparison-bar-chart*.tsx`, `src/components/ui/chart.tsx`, their tests, or the `recharts`
+  dependency — they are kept deliberately for the trend chart (see Resolved decisions).
+
+## Success criteria
+
+- [ ] Both dashboard cards render a ranked table; no `ComparisonBarChart` is mounted.
+- [ ] Every category shows its amount as text — no hover needed to read any figure.
+- [ ] Categories are ordered descending by current-period amount, and every category with data in
+      either period is rendered — no cap, no truncation.
+- [ ] A category present only in the previous period renders with a −100 % variation.
+- [ ] A category present only in the current period renders "nuevo".
+- [ ] Expense increases render red, expense decreases green; donations the reverse.
+- [ ] The dashboard issues the same six report requests as before this change.
+- [ ] `pnpm run check`, `pnpm run typecheck` and `pnpm run test` all pass; `stat-card.test.tsx` is
+      unmodified.
+- [ ] Dark mode and a 375 px viewport both render without overflow.
+
+## Resolved decisions
+
+1. **Dead chart code stays.** After this change `comparison-bar-chart.tsx`, its lazy wrapper and its
+   tests have no callers, and `src/components/ui/chart.tsx` + `recharts` (3.8.0) are used by nothing
+   else. They stay in the repo so the trend chart can pick them back up when
+   [donations-api#51](https://github.com/jorgetroya80/donations-api/issues/51) ships. Their tests
+   keep running. Since nothing imports the lazy wrapper, the recharts chunk simply stops being
+   fetched on the dashboard route — `recharts` remains a dependency and is no longer in any route's
+   critical path.
+2. **Every category is shown.** No row cap, no "ver todo" affordance. All eight expense categories
+   render when they have data in either period; the card grows to fit.

--- a/src/features/dashboard/category-ranking.test.tsx
+++ b/src/features/dashboard/category-ranking.test.tsx
@@ -1,0 +1,119 @@
+import { render, screen, within } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { CategoryRanking, type RankingItem } from './category-ranking'
+
+const items: RankingItem[] = [
+  { key: 'RENT', label: 'Alquiler', current: 1500, previous: 1000 },
+  { key: 'IRPF', label: 'IRPF', current: 21450, previous: 21450 },
+  { key: 'MAINTENANCE', label: 'Mantenimiento', current: 310, previous: 400 },
+]
+
+function rowLabels() {
+  return screen
+    .getAllByRole('row')
+    .map((row) => within(row).getAllByRole('cell')[0]?.textContent)
+}
+
+function bars(container: HTMLElement) {
+  return Array.from(
+    container.querySelectorAll<HTMLElement>('[aria-hidden="true"] > div')
+  )
+}
+
+describe('CategoryRanking', () => {
+  it('sorts rows descending by current amount regardless of input order', () => {
+    render(<CategoryRanking items={items} title="Gastos por categoría" />)
+    expect(rowLabels()).toEqual(['IRPF', 'Alquiler', 'Mantenimiento'])
+  })
+
+  it('breaks ties by label so the order is stable across renders', () => {
+    render(
+      <CategoryRanking
+        title="Gastos por categoría"
+        items={[
+          { key: 'B', label: 'Bravo', current: 100, previous: 100 },
+          { key: 'A', label: 'Alfa', current: 100, previous: 100 },
+        ]}
+      />
+    )
+    expect(rowLabels()).toEqual(['Alfa', 'Bravo'])
+  })
+
+  it('gives the largest row a full-width bar and scales the rest', () => {
+    const { container } = render(
+      <CategoryRanking items={items} title="Gastos por categoría" />
+    )
+
+    const [largest, second] = bars(container)
+    expect(largest?.style.width).toBe('100%')
+    expect(second?.style.width).not.toBe('100%')
+    expect(Number.parseFloat(second?.style.width ?? '0')).toBeCloseTo(
+      (1500 / 21450) * 100
+    )
+  })
+
+  it('labels a category with no previous amount as new instead of a percentage', () => {
+    render(
+      <CategoryRanking
+        title="Gastos por categoría"
+        items={[{ key: 'RENT', label: 'Alquiler', current: 500, previous: 0 }]}
+      />
+    )
+
+    expect(screen.getByText('nuevo')).toBeInTheDocument()
+    expect(screen.queryByText(/%/)).not.toBeInTheDocument()
+  })
+
+  it('renders a category that dropped to zero as a 100% decrease', () => {
+    render(
+      <CategoryRanking
+        title="Gastos por categoría"
+        items={[{ key: 'RENT', label: 'Alquiler', current: 0, previous: 500 }]}
+      />
+    )
+
+    expect(screen.getByText(/↓ 100\.0%/)).toBeInTheDocument()
+    expect(screen.queryByText('nuevo')).not.toBeInTheDocument()
+  })
+
+  it('renders the exact amount as text for every row', () => {
+    render(<CategoryRanking items={items} title="Gastos por categoría" />)
+
+    expect(screen.getByText(/21[.\s]?450/)).toBeInTheDocument()
+    expect(screen.getByText(/1[.\s]?500/)).toBeInTheDocument()
+    expect(screen.getByText(/310/)).toBeInTheDocument()
+  })
+
+  it('colours an increase as bad when inverted and as good when not', () => {
+    const growing: RankingItem[] = [
+      { key: 'RENT', label: 'Alquiler', current: 200, previous: 100 },
+    ]
+
+    const expenses = render(
+      <CategoryRanking items={growing} title="Gastos" inverted />
+    )
+    expect(expenses.getByText(/↑ 100\.0%/)).toHaveClass('text-destructive')
+    expenses.unmount()
+
+    const donations = render(
+      <CategoryRanking items={growing} title="Donaciones" />
+    )
+    expect(donations.getByText(/↑ 100\.0%/)).toHaveClass('text-success')
+  })
+
+  it('renders nothing when there are no items', () => {
+    const { container } = render(
+      <CategoryRanking items={[]} title="Gastos por categoría" />
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('names the table for screen readers', () => {
+    render(<CategoryRanking items={items} title="Gastos por categoría" />)
+    expect(
+      screen.getByRole('table', {
+        name: /Gastos por categoría, importe y variación/,
+      })
+    ).toBeInTheDocument()
+  })
+})

--- a/src/features/dashboard/category-ranking.tsx
+++ b/src/features/dashboard/category-ranking.tsx
@@ -1,0 +1,79 @@
+import { useTranslation } from 'react-i18next'
+import { formatCurrency } from '@/lib/formatters'
+import { calcPctChange } from './financial-overview.utils'
+import { PctChange } from './pct-change'
+
+export interface RankingItem {
+  key: string
+  label: string
+  current: number
+  previous: number | null | undefined
+}
+
+export interface CategoryRankingProps {
+  items: RankingItem[]
+  /** Title of the card this table sits in, used for the screen-reader caption. */
+  title: string
+  /** True for expenses, where an increase is bad. */
+  inverted?: boolean
+}
+
+export function CategoryRanking({
+  items,
+  title,
+  inverted,
+}: CategoryRankingProps) {
+  const { t } = useTranslation()
+
+  if (items.length === 0) return null
+
+  // Ties break by label so the order does not jump between renders.
+  const rows = [...items].sort(
+    (a, b) => b.current - a.current || a.label.localeCompare(b.label)
+  )
+  const max = rows[0]?.current ?? 0
+
+  return (
+    <table className="w-full text-sm">
+      <caption className="sr-only">
+        {t('dashboard.rankingCaption', { title })}
+      </caption>
+      <tbody>
+        {rows.map((item) => (
+          <tr key={item.key}>
+            <td className="py-1.5 pr-3 text-right align-middle whitespace-nowrap">
+              {item.label}
+            </td>
+            <td className="w-full py-1.5">
+              <div aria-hidden="true" className="bg-muted h-5 rounded">
+                <div
+                  className="bg-chart-1 h-5 min-w-[3px] rounded"
+                  style={{
+                    width: `${max > 0 ? (item.current / max) * 100 : 0}%`,
+                  }}
+                />
+              </div>
+            </td>
+            <td className="py-1.5 pl-3 text-right font-medium whitespace-nowrap">
+              {formatCurrency(item.current)}
+            </td>
+            <td className="py-1.5 pl-3 text-right whitespace-nowrap">
+              {calcPctChange(item.current, item.previous) == null &&
+              item.current > 0 ? (
+                <span className="text-muted-foreground text-xs">
+                  {t('dashboard.newCategory')}
+                </span>
+              ) : (
+                <PctChange
+                  current={item.current}
+                  previous={item.previous}
+                  inverted={inverted}
+                />
+              )}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}

--- a/src/features/dashboard/financial-overview.test.tsx
+++ b/src/features/dashboard/financial-overview.test.tsx
@@ -47,17 +47,6 @@ describe('FinancialOverview', () => {
     })
   })
 
-  it('reserves a stable height on both ranking cards', () => {
-    const { container } = renderWithProviders(<FinancialOverview />)
-
-    // The empty state is shorter than a rendered ranking, so without a floor
-    // the cards grow when a range with data is picked.
-    const contents = container.querySelectorAll(
-      '[data-slot="card-content"].min-h-75'
-    )
-    expect(contents).toHaveLength(2)
-  })
-
   it('renders card titles', () => {
     renderWithProviders(<FinancialOverview />)
 

--- a/src/features/dashboard/financial-overview.test.tsx
+++ b/src/features/dashboard/financial-overview.test.tsx
@@ -1,7 +1,17 @@
-import { screen, waitFor } from '@testing-library/react'
+import { screen, waitFor, within } from '@testing-library/react'
+import { HttpResponse, http } from 'msw'
 import { describe, expect, it } from 'vitest'
+import { currentMonthRange } from '@/lib/formatters'
+import { server } from '@/test/msw-server'
 import { renderWithProviders } from '@/test/test-utils'
 import { FinancialOverview } from './financial-overview'
+import { previousRange } from './financial-overview.utils'
+
+// The ranking cards repeat the same figures, so the stat-card assertions are
+// scoped to the stat row.
+function statCards(container: HTMLElement) {
+  return within(container.querySelector('[aria-busy]') as HTMLElement)
+}
 
 describe('FinancialOverview', () => {
   it('renders section heading', () => {
@@ -10,18 +20,19 @@ describe('FinancialOverview', () => {
   })
 
   it('renders balance cards with data from API', async () => {
-    renderWithProviders(<FinancialOverview />)
+    const { container } = renderWithProviders(<FinancialOverview />)
+    const stats = statCards(container)
 
     await waitFor(() => {
-      expect(screen.getByText(/5[.\s]?000/)).toBeInTheDocument()
+      expect(stats.getByText(/5[.\s]?000/)).toBeInTheDocument()
     })
 
-    expect(screen.getByText(/3[.\s]?000/)).toBeInTheDocument()
-    expect(screen.getByText(/2[.\s]?000/)).toBeInTheDocument()
+    expect(stats.getByText(/3[.\s]?000/)).toBeInTheDocument()
+    expect(stats.getByText(/2[.\s]?000/)).toBeInTheDocument()
   })
 
   it('renders the stat cards while loading rather than a skeleton above them', async () => {
-    renderWithProviders(<FinancialOverview />)
+    const { container } = renderWithProviders(<FinancialOverview />)
 
     // The cards are in the tree from the first paint, showing placeholders.
     expect(screen.getByText('Ingresos totales')).toBeInTheDocument()
@@ -32,16 +43,15 @@ describe('FinancialOverview', () => {
     expect(screen.queryByLabelText('Cargando...')).not.toBeInTheDocument()
 
     await waitFor(() => {
-      expect(screen.getByText(/5[.\s]?000/)).toBeInTheDocument()
+      expect(statCards(container).getByText(/5[.\s]?000/)).toBeInTheDocument()
     })
   })
 
-  it('reserves a stable height on both chart cards', () => {
+  it('reserves a stable height on both ranking cards', () => {
     const { container } = renderWithProviders(<FinancialOverview />)
 
-    // The empty state is shorter than a rendered chart, so without a floor
-    // the cards grow when a range with data is picked. 300px covers the
-    // tallest chart box (max-h-75) in either card.
+    // The empty state is shorter than a rendered ranking, so without a floor
+    // the cards grow when a range with data is picked.
     const contents = container.querySelectorAll(
       '[data-slot="card-content"].min-h-75'
     )
@@ -54,5 +64,56 @@ describe('FinancialOverview', () => {
     expect(screen.getByText('Ingresos totales')).toBeInTheDocument()
     expect(screen.getByText('Gastos totales')).toBeInTheDocument()
     expect(screen.getByText('Balance neto')).toBeInTheDocument()
+  })
+
+  it('ranks every category with its amount, no hover needed', async () => {
+    renderWithProviders(<FinancialOverview />)
+
+    const table = await screen.findByRole('table', {
+      name: /Gastos por categoría/,
+    })
+    await waitFor(() => {
+      expect(within(table).getAllByRole('row')).toHaveLength(2)
+    })
+    expect(within(table).getByText('Alquiler')).toBeInTheDocument()
+    expect(within(table).getByText('Servicios')).toBeInTheDocument()
+  })
+
+  it('keeps a category that only has data in the previous period', async () => {
+    const range = currentMonthRange()
+    const previous = previousRange(range.from, range.to)
+
+    server.use(
+      http.get('*/api/v1/reports/expenses', ({ request }) => {
+        const from = new URL(request.url).searchParams.get('from')
+        const isPrevious = from === previous.from
+        return HttpResponse.json({
+          from,
+          to: new URL(request.url).searchParams.get('to'),
+          totalsByCategory: isPrevious
+            ? [
+                { category: 'RENT', total: 1500 },
+                { category: 'MAINTENANCE', total: 400 },
+              ]
+            : [{ category: 'RENT', total: 1500 }],
+          grandTotal: isPrevious ? 1900 : 1500,
+        })
+      })
+    )
+
+    renderWithProviders(<FinancialOverview />)
+
+    // Mantenimiento dropped to zero this period: it must still show, as -100%.
+    const row = await screen.findByText('Mantenimiento')
+    expect(row.closest('tr')).toHaveTextContent(/↓ 100\.0%/)
+  })
+
+  it('shows each period total from the report grand totals', async () => {
+    renderWithProviders(<FinancialOverview />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/total .*5[.\s]?000/)).toBeInTheDocument()
+    })
+    expect(screen.getByText(/total .*3[.\s]?000/)).toBeInTheDocument()
   })
 })

--- a/src/features/dashboard/financial-overview.tsx
+++ b/src/features/dashboard/financial-overview.tsx
@@ -135,7 +135,7 @@ export function FinancialOverview() {
               </span>
             )}
           </CardHeader>
-          <CardContent className="min-h-75">
+          <CardContent>
             {donationRows.length > 0 ? (
               <CategoryRanking items={donationRows} title={donationsTitle} />
             ) : (
@@ -158,7 +158,7 @@ export function FinancialOverview() {
               </span>
             )}
           </CardHeader>
-          <CardContent className="min-h-75">
+          <CardContent>
             {expenseRows.length > 0 ? (
               <CategoryRanking
                 items={expenseRows}

--- a/src/features/dashboard/financial-overview.tsx
+++ b/src/features/dashboard/financial-overview.tsx
@@ -5,11 +5,10 @@ import { DateRangePicker } from '@/components/date-range-picker'
 import { EmptyState } from '@/components/empty-state'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import type { ChartConfig } from '@/components/ui/chart'
 import { useDonationReport, useExpenseReport } from '@/features/reports'
-import { currentMonthRange, formatDate } from '@/lib/formatters'
+import { currentMonthRange, formatCurrency, formatDate } from '@/lib/formatters'
 import { getProblemMessage } from '@/lib/get-problem-message'
-import { ComparisonBarChart } from './comparison-bar-chart.lazy'
+import { CategoryRanking, type RankingItem } from './category-ranking'
 import { previousRange } from './financial-overview.utils'
 import { StatCard } from './stat-card'
 import { useBalance } from './use-dashboard-data'
@@ -19,16 +18,11 @@ const donationTypes = ['TITHE', 'OFFERING', 'SPECIAL_OFFERING', 'OTHER']
 export function FinancialOverview() {
   const { t } = useTranslation()
 
-  const donationChartConfig: ChartConfig = Object.fromEntries(
-    donationTypes.map((type, i) => [
-      type,
-      { label: t(`donations.types.${type}`), color: `var(--chart-${i + 1})` },
-    ])
+  const donationTypeLabels: Record<string, string> = Object.fromEntries(
+    donationTypes.map((type) => [type, t(`donations.types.${type}`)])
   )
-  const comparisonConfig: ChartConfig = {
-    current: { label: t('dashboard.currentPeriod'), color: 'var(--chart-1)' },
-    previous: { label: t('dashboard.previousPeriod'), color: 'var(--chart-3)' },
-  }
+  const donationsTitle = t('dashboard.donationsByType')
+  const expensesTitle = t('dashboard.expensesByCategory')
   const [range, setRange] = useState(currentMonthRange)
 
   const dateParams = {
@@ -48,37 +42,40 @@ export function FinancialOverview() {
     balance.isLoading || donations.isLoading || expenses.isLoading
   const error = balance.error || donations.error || expenses.error
 
-  const makeDonationItem = (type: string | null | undefined) => ({
-    type: donationChartConfig[type ?? '']?.label ?? type ?? '',
-    current:
-      donations.data?.totalsByType?.find((d) => d.type === type)?.total ?? 0,
-    previous:
-      prevDonations.data?.totalsByType?.find((d) => d.type === type)?.total ??
-      0,
-  })
-
+  // A category can appear in either period only: unioning both keeps a
+  // category that dropped to zero visible, as the -100% it is.
   const allDonationTypes = Array.from(
     new Set([
       ...(donations.data?.totalsByType?.map((d) => d.type) ?? []),
       ...(prevDonations.data?.totalsByType?.map((d) => d.type) ?? []),
     ])
   )
-  const titheData = allDonationTypes
-    .filter((t) => t === 'TITHE')
-    .map(makeDonationItem)
-  const otherDonationsData = allDonationTypes
-    .filter((t) => t !== 'TITHE')
-    .map(makeDonationItem)
+  const donationRows: RankingItem[] = allDonationTypes.map((type) => ({
+    key: type ?? '',
+    label: donationTypeLabels[type ?? ''] ?? type ?? '',
+    current:
+      donations.data?.totalsByType?.find((d) => d.type === type)?.total ?? 0,
+    previous:
+      prevDonations.data?.totalsByType?.find((d) => d.type === type)?.total ??
+      0,
+  }))
 
-  const expenseChartData =
-    expenses.data?.totalsByCategory?.map((cur) => ({
-      category: cur.category ? t(`expenses.categories.${cur.category}`) : '',
-      current: cur.total ?? 0,
-      previous:
-        prevExpenses.data?.totalsByCategory?.find(
-          (e) => e.category === cur.category
-        )?.total ?? 0,
-    })) ?? []
+  const allExpenseCategories = Array.from(
+    new Set([
+      ...(expenses.data?.totalsByCategory?.map((e) => e.category) ?? []),
+      ...(prevExpenses.data?.totalsByCategory?.map((e) => e.category) ?? []),
+    ])
+  )
+  const expenseRows: RankingItem[] = allExpenseCategories.map((category) => ({
+    key: category ?? '',
+    label: category ? t(`expenses.categories.${category}`) : '',
+    current:
+      expenses.data?.totalsByCategory?.find((e) => e.category === category)
+        ?.total ?? 0,
+    previous:
+      prevExpenses.data?.totalsByCategory?.find((e) => e.category === category)
+        ?.total ?? 0,
+  }))
 
   return (
     <div className="space-y-4">
@@ -128,32 +125,19 @@ export function FinancialOverview() {
 
       <div className="grid gap-4 lg:grid-cols-2">
         <Card>
-          <CardHeader>
-            <CardTitle>{t('dashboard.donationsByType')}</CardTitle>
+          <CardHeader className="flex flex-row items-baseline justify-between gap-3">
+            <CardTitle>{donationsTitle}</CardTitle>
+            {donations.data?.grandTotal != null && (
+              <span className="text-muted-foreground text-sm whitespace-nowrap">
+                {t('dashboard.periodTotal', {
+                  amount: formatCurrency(donations.data.grandTotal),
+                })}
+              </span>
+            )}
           </CardHeader>
           <CardContent className="min-h-75">
-            {titheData.length > 0 || otherDonationsData.length > 0 ? (
-              <div className="space-y-4">
-                {titheData.length > 0 && (
-                  <ComparisonBarChart
-                    data={titheData}
-                    config={comparisonConfig}
-                    categoryKey="type"
-                    categoryWidth={120}
-                    className="max-h-20"
-                  />
-                )}
-                {otherDonationsData.length > 0 && (
-                  <ComparisonBarChart
-                    data={otherDonationsData}
-                    config={comparisonConfig}
-                    categoryKey="type"
-                    categoryWidth={120}
-                    showLegend
-                    className="max-h-45"
-                  />
-                )}
-              </div>
+            {donationRows.length > 0 ? (
+              <CategoryRanking items={donationRows} title={donationsTitle} />
             ) : (
               <EmptyState
                 icon={<BarChart3 size={40} />}
@@ -164,18 +148,22 @@ export function FinancialOverview() {
         </Card>
 
         <Card>
-          <CardHeader>
-            <CardTitle>{t('dashboard.expensesByCategory')}</CardTitle>
+          <CardHeader className="flex flex-row items-baseline justify-between gap-3">
+            <CardTitle>{expensesTitle}</CardTitle>
+            {expenses.data?.grandTotal != null && (
+              <span className="text-muted-foreground text-sm whitespace-nowrap">
+                {t('dashboard.periodTotal', {
+                  amount: formatCurrency(expenses.data.grandTotal),
+                })}
+              </span>
+            )}
           </CardHeader>
           <CardContent className="min-h-75">
-            {expenseChartData.length > 0 ? (
-              <ComparisonBarChart
-                data={expenseChartData}
-                config={comparisonConfig}
-                categoryKey="category"
-                categoryWidth={100}
-                showLegend
-                className="max-h-75"
+            {expenseRows.length > 0 ? (
+              <CategoryRanking
+                items={expenseRows}
+                title={expensesTitle}
+                inverted
               />
             ) : (
               <EmptyState

--- a/src/features/dashboard/pct-change.tsx
+++ b/src/features/dashboard/pct-change.tsx
@@ -1,0 +1,35 @@
+import { calcPctChange } from './financial-overview.utils'
+
+export function PctChange({
+  current,
+  previous,
+  inverted = false,
+}: {
+  current: number | null | undefined
+  previous: number | null | undefined
+  inverted?: boolean
+}) {
+  const pct = calcPctChange(current, previous)
+  // The previous-period queries resolve independently of the current-period
+  // ones, so hold the line's space until they land or the card grows a row.
+  if (pct == null)
+    return (
+      <span
+        data-slot="pct-change"
+        aria-hidden="true"
+        className="invisible mt-1 text-xs font-medium"
+      >
+        &nbsp;
+      </span>
+    )
+  const isPositive = pct > 0
+  const isGood = inverted ? !isPositive : isPositive
+  return (
+    <span
+      data-slot="pct-change"
+      className={`mt-1 text-xs font-medium ${isGood ? 'text-success' : 'text-destructive'}`}
+    >
+      {isPositive ? '↑' : '↓'} {Math.abs(pct).toFixed(1)}%
+    </span>
+  )
+}

--- a/src/features/dashboard/stat-card.tsx
+++ b/src/features/dashboard/stat-card.tsx
@@ -1,41 +1,7 @@
 import type { ReactNode } from 'react'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { formatCurrency } from '@/lib/formatters'
-import { calcPctChange } from './financial-overview.utils'
-
-function PctChange({
-  current,
-  previous,
-  inverted = false,
-}: {
-  current: number | null | undefined
-  previous: number | null | undefined
-  inverted?: boolean
-}) {
-  const pct = calcPctChange(current, previous)
-  // The previous-period queries resolve independently of the current-period
-  // ones, so hold the line's space until they land or the card grows a row.
-  if (pct == null)
-    return (
-      <span
-        data-slot="pct-change"
-        aria-hidden="true"
-        className="invisible mt-1 text-xs font-medium"
-      >
-        &nbsp;
-      </span>
-    )
-  const isPositive = pct > 0
-  const isGood = inverted ? !isPositive : isPositive
-  return (
-    <span
-      data-slot="pct-change"
-      className={`mt-1 text-xs font-medium ${isGood ? 'text-success' : 'text-destructive'}`}
-    >
-      {isPositive ? '↑' : '↓'} {Math.abs(pct).toFixed(1)}%
-    </span>
-  )
-}
+import { PctChange } from './pct-change'
 
 interface StatCardProps {
   label: string

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -41,7 +41,10 @@
     "manageUsers": "Administrar usuarios",
     "financialOverview": "Resumen financiero",
     "currentPeriod": "Actual",
-    "previousPeriod": "Anterior"
+    "previousPeriod": "Anterior",
+    "newCategory": "nuevo",
+    "periodTotal": "total {{amount}}",
+    "rankingCaption": "{{title}}, importe y variación frente al periodo anterior"
   },
   "donations": {
     "title": "Donaciones",


### PR DESCRIPTION
## What

The two chart cards on the treasurer dashboard — "Donaciones por tipo" and "Gastos por categoría" — go from comparison bars to a ranking: one row per category, sorted descending, with a proportional bar, the exact amount, and the variation against the previous period.

Spec: [`docs/PRD-dashboard-category-ranking.md`](docs/PRD-dashboard-category-ranking.md).

## Why

The current charts draw two series with no axis and no value labels, so no figure is readable without hovering. A shared linear scale flattens everything below the largest category: with IRPF at 21.450 € and Mantenimiento at 310 €, the small bar is a 2 px sliver. And the comparison they perform (current vs previous) is already answered by the three `StatCard`s directly above them.

## Detail

- **New `category-ranking.tsx`**, presentational: takes already-translated rows, sorts descending (ties broken by label, so the order does not jump between renders) and sizes each bar against the card's maximum.
- **`PctChange` extracted** from `stat-card.tsx` into its own file, so the ranking and the stat cards above it speak the same visual language. `stat-card.test.tsx` is untouched — that is the proof the extraction preserved behaviour.
- **Expense rows union both periods.** They used to map over the current period's `totalsByCategory` only, so a category that dropped to zero disappeared instead of showing its −100 %. Donations already did this; both are consistent now.
- **Card totals** come from `grandTotal`, a DTO field the dashboard was not using.
- **Colour semantics**: in expenses an increase is bad (red) and a decrease good (green); in donations the reverse.
- **Accessibility**: rendered as a `<table>` — this is tabular data, and a table gives screen readers row and column context for free. The bar sits inside the cell as an `aria-hidden` decoration. `<caption class="sr-only">` because the visible title lives outside the table.

No new requests: the dashboard's six queries are unchanged.

## Deliberately untouched

`comparison-bar-chart*.tsx`, `src/components/ui/chart.tsx` and the `recharts` dependency stay in the repo on purpose, for the monthly trend chart that is coming. Nothing imports them, so the recharts chunk is no longer fetched on the dashboard route.

That chart needs time-series endpoints the API does not have yet: [donations-api#51](https://github.com/jorgetroya80/donations-api/issues/51).

## Verification

- `pnpm run typecheck` clean.
- `pnpm run test`: 421 tests across 65 files, green.
- New tests in `category-ranking.test.tsx`: ordering, proportional width, "nuevo" when the previous value is 0, −100 % when the current value is 0, colour inversion via `inverted`, and the empty list.
- Still to do before merge: manual pass in dark mode and at a 375 px viewport.
